### PR TITLE
Ft/defaultsla

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -19,14 +19,54 @@ pub struct SLAConfig {
 
 #[contractimpl]
 impl SLACalculatorContract {
-    pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&ADMIN_KEY) {
-            panic!("Already initialized");
-        }
-
-        env.storage().instance().set(&ADMIN_KEY, &admin);
-        env.storage().instance().set(&CONFIG_KEY, &Map::<Symbol, SLAConfig>::new(&env));
+   pub fn initialize(env: Env, admin: Address) {
+    if env.storage().instance().has(&ADMIN_KEY) {
+        panic!("Already initialized");
     }
+
+    env.storage().instance().set(&ADMIN_KEY, &admin);
+
+    let mut configs = Map::<Symbol, SLAConfig>::new(&env);
+
+    
+    configs.set(
+        symbol_short!("critical"),
+        SLAConfig {
+            threshold_minutes: 15,
+            penalty_per_minute: 100,
+            reward_base: 750,
+        },
+    );
+
+    configs.set(
+        symbol_short!("high"),
+        SLAConfig {
+            threshold_minutes: 30,
+            penalty_per_minute: 50,
+            reward_base: 750,
+        },
+    );
+
+    configs.set(
+        symbol_short!("medium"),
+        SLAConfig {
+            threshold_minutes: 60,
+            penalty_per_minute: 25,
+            reward_base: 750,
+        },
+    );
+
+    configs.set(
+        symbol_short!("low"),
+        SLAConfig {
+            threshold_minutes: 120,
+            penalty_per_minute: 10,
+            reward_base: 600,
+        },
+    );
+
+    env.storage().instance().set(&CONFIG_KEY, &configs);
+}
 
     pub fn get_admin(env: Env) -> Address {
         env.storage()

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -52,3 +52,25 @@ fn test_non_admin_cannot_set_config() {
         &750,
     );
 }
+
+#[test]
+fn test_defaults_exist_after_initialize() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &contract_id);
+
+    let admin = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin);
+
+    let critical = client.get_config(&symbol_short!("critical"));
+    assert_eq!(critical.threshold_minutes, 15);
+
+    let high = client.get_config(&symbol_short!("high"));
+    assert_eq!(high.threshold_minutes, 30);
+
+    let medium = client.get_config(&symbol_short!("medium"));
+    assert_eq!(medium.threshold_minutes, 60);
+
+    let low = client.get_config(&symbol_short!("low"));
+    assert_eq!(low.threshold_minutes, 120);
+}


### PR DESCRIPTION
This PR preloads default SLA configurations for all severity levels during contract deployment. With this change, the contract works immediately after deploy, without requiring manual configuration.

closes #8