### PR TITLE
SC-051/052/053/054: workspace, metadata, migrate, unknown-severity tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["sla_calculator"]
+resolver = "2"

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -130,6 +130,17 @@ pub struct SLAResultSchema {
     pub rating_poor: Symbol,
 }
 
+/// #60 – Single introspection call for backend clients.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractMetadata {
+    pub contract_name: Symbol,
+    pub storage_version: u32,
+    pub result_schema_version: u32,
+    pub supported_severities: Vec<Symbol>,
+    pub features: Vec<Symbol>,
+}
+
 /// #29 – Cumulative on-chain SLA performance metrics.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -212,6 +223,44 @@ impl SLACalculatorContract {
         env.storage().instance().set(&CONFIG_KEY, &configs);
         Self::write_version(&env);
         Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // #61 – Storage migration harness
+    // -------------------------------------------------------------------
+
+    /// Migrate storage from a previous version to the current one.
+    /// Must be called by admin after a contract upgrade that bumps STORAGE_VERSION.
+    /// Currently handles v0→v1 (first-time version stamp on legacy state).
+    pub fn migrate(env: Env, caller: Address) -> Result<(), SLAError> {
+        // Require admin without going through check_version (state may be unversioned)
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&ADMIN_KEY)
+            .ok_or(SLAError::NotInitialized)?;
+        if caller != admin {
+            return Err(SLAError::Unauthorized);
+        }
+
+        let stored: u32 = env
+            .storage()
+            .instance()
+            .get(&STORAGE_VERSION_KEY)
+            .unwrap_or(0);
+
+        if stored == STORAGE_VERSION {
+            // Already current – idempotent no-op
+            return Ok(());
+        }
+
+        // v0 → v1: stamp the version; all other fields were set by initialize
+        if stored == 0 {
+            Self::write_version(&env);
+            return Ok(());
+        }
+
+        Err(SLAError::VersionMismatch)
     }
 
     // -------------------------------------------------------------------
@@ -402,6 +451,31 @@ impl SLACalculatorContract {
             rating_excellent: symbol_short!("excel"),
             rating_good: symbol_short!("good"),
             rating_poor: symbol_short!("poor"),
+        })
+    }
+
+    /// #60 – Returns static contract capabilities for backend introspection.
+    pub fn get_contract_metadata(env: Env) -> Result<ContractMetadata, SLAError> {
+        Self::check_version(&env)?;
+        let mut severities = Vec::new(&env);
+        severities.push_back(symbol_short!("critical"));
+        severities.push_back(symbol_short!("high"));
+        severities.push_back(symbol_short!("medium"));
+        severities.push_back(symbol_short!("low"));
+
+        let mut features = Vec::new(&env);
+        features.push_back(symbol_short!("calc"));
+        features.push_back(symbol_short!("audit"));
+        features.push_back(symbol_short!("pause"));
+        features.push_back(symbol_short!("stats"));
+        features.push_back(symbol_short!("history"));
+
+        Ok(ContractMetadata {
+            contract_name: symbol_short!("sla_calc"),
+            storage_version: STORAGE_VERSION,
+            result_schema_version: RESULT_SCHEMA_VERSION,
+            supported_severities: severities,
+            features,
         })
     }
 

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -1194,3 +1194,131 @@ mod snapshots {
         );
     }
 }
+
+// ============================================================
+// #60 – Contract metadata / capabilities view
+// ============================================================
+
+#[test]
+fn test_get_contract_metadata_returns_expected_fields() {
+    let (_env, client, _actors) = setup();
+    let meta = client.get_contract_metadata();
+    assert_eq!(meta.contract_name, symbol_short!("sla_calc"));
+    assert_eq!(meta.storage_version, 1);
+    assert_eq!(meta.result_schema_version, 1);
+    assert_eq!(meta.supported_severities.len(), 4);
+    assert_eq!(meta.features.len(), 5);
+}
+
+#[test]
+fn test_get_contract_metadata_severities_are_canonical() {
+    let (_env, client, _actors) = setup();
+    let meta = client.get_contract_metadata();
+    assert_eq!(meta.supported_severities.get(0).unwrap(), symbol_short!("critical"));
+    assert_eq!(meta.supported_severities.get(1).unwrap(), symbol_short!("high"));
+    assert_eq!(meta.supported_severities.get(2).unwrap(), symbol_short!("medium"));
+    assert_eq!(meta.supported_severities.get(3).unwrap(), symbol_short!("low"));
+}
+
+#[test]
+fn test_get_contract_metadata_is_deterministic() {
+    let (_env, client, _actors) = setup();
+    let m1 = client.get_contract_metadata();
+    let m2 = client.get_contract_metadata();
+    assert_eq!(m1.storage_version, m2.storage_version);
+    assert_eq!(m1.result_schema_version, m2.result_schema_version);
+    assert_eq!(m1.contract_name, m2.contract_name);
+}
+
+// ============================================================
+// #61 – Storage migration harness
+// ============================================================
+
+#[test]
+fn test_migrate_is_idempotent_when_already_current() {
+    let (_env, client, actors) = setup();
+    // Already at v1 – migrate should succeed without error
+    client.migrate(&actors.admin);
+    client.migrate(&actors.admin);
+    // Contract still functional
+    assert_eq!(client.get_admin(), actors.admin);
+}
+
+#[test]
+#[should_panic]
+fn test_migrate_rejected_for_non_admin() {
+    let (_env, client, actors) = setup();
+    client.migrate(&actors.stranger);
+}
+
+#[test]
+#[should_panic]
+fn test_check_version_rejects_version_mismatch() {
+    // Simulate a future version stored in state by writing a different version
+    // directly, then calling any versioned endpoint.
+    let env = Env::default();
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    // Manually overwrite the stored version to simulate a future schema
+    env.as_contract(&cid, || {
+        env.storage()
+            .instance()
+            .set(&STORAGE_VERSION_KEY, &99u32);
+    });
+
+    // Any versioned call must now panic with VersionMismatch
+    client.get_admin();
+}
+
+// ============================================================
+// #62 – Unknown-severity rejection
+// ============================================================
+
+#[test]
+#[should_panic]
+fn test_calculate_sla_rejects_unknown_severity() {
+    let (env, client, actors) = setup();
+    client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("UNK001"),
+        &Symbol::new(&env, "unknown"),
+        &10,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_calculate_sla_view_rejects_unknown_severity() {
+    let (env, client, _actors) = setup();
+    client.calculate_sla_view(
+        &symbol_short!("UNK002"),
+        &Symbol::new(&env, "unknown"),
+        &10,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_get_config_rejects_unknown_severity() {
+    let (env, client, _actors) = setup();
+    client.get_config(&Symbol::new(&env, "unknown"));
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_then_calculate_unknown_severity_still_rejects_other_unknown() {
+    // Even after adding a custom severity via set_config, a different unknown still fails
+    let (env, client, actors) = setup();
+    client.set_config(&actors.admin, &Symbol::new(&env, "custom"), &10, &50, &500);
+    // "bogus" was never configured
+    client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("UNK003"),
+        &Symbol::new(&env, "bogus"),
+        &5,
+    );
+}


### PR DESCRIPTION
## Summary

Resolves #59, closes #60, closes #61, closes #62.

### Changes

**#59 – Root Cargo workspace**
- Added `Cargo.toml` at repo root with `[workspace]` pointing to `sla_calculator`; resolver = 2.

**#60 – Contract metadata view**
- Added `ContractMetadata` struct with `contract_name`, `storage_version`, `result_schema_version`, `supported_severities`, `features`.
- Added `get_contract_metadata()` read-only endpoint; deterministic, no state mutation.
- 3 tests: field correctness, canonical severity order, determinism.

**#61 – Storage migration harness**
- Added `migrate(admin)` function: admin-only, idempotent at current version, handles v0→v1 stamp, returns `VersionMismatch` for unknown future versions.
- 3 tests: idempotent call, non-admin rejection, version-mismatch panic via `env.as_contract` storage override.

**#62 – Unknown-severity rejection**
- 4 tests covering `calculate_sla`, `calculate_sla_view`, `get_config`, and a custom-severity-added-but-different-unknown scenario — all must panic with `ConfigNotFound`.

## Tested
`cargo test` not runnable in this environment (no Rust toolchain); logic reviewed against existing patterns and Soroban SDK 21 testutils API.