### PR TITLE
feat: two-step admin/operator transfer, admin renounce, pause metadat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,36 @@ Examples:
 - there is not yet a broader contract workspace with escrow or settlement modules
 - cross-repo contract invocation is still a backend integration concern, not something managed here directly
 
+## Governance Policy
+
+### Admin transfer (two-step)
+
+Admin authority is transferred via a two-step flow to prevent accidental reassignment:
+
+1. Current admin calls `propose_admin(caller, new_admin)` — stores a pending proposal.
+2. Proposed admin calls `accept_admin(caller)` — atomically promotes caller to admin and clears the proposal.
+
+The old admin retains authority until `accept_admin` succeeds. `get_pending_admin()` is queryable at any time.
+
+### Operator handoff (two-step)
+
+Operator rotation follows the same pattern:
+
+1. Admin calls `propose_operator(caller, new_operator)`.
+2. New operator calls `accept_operator(caller)` to activate.
+
+`get_pending_operator()` exposes the pending state for governance visibility.
+
+### Admin renounce
+
+`renounce_admin(caller)` permanently removes admin authority. This is **irreversible**: after renounce, all admin-gated functions (`set_config`, `pause`, `unpause`, `set_operator`, `prune_history`) are permanently locked. Any pending admin proposal is also cleared atomically.
+
+Backend operators should treat a renounced contract as immutable from a governance perspective. There is no recovery path by design — if recovery is needed, redeploy and reinitialize.
+
+### Pause metadata
+
+`pause(caller, reason)` stores a `PauseInfo` struct containing the reason string and the ledger timestamp at pause time. `get_pause_info()` returns this metadata while the contract is paused. `unpause` clears it. This gives backend operators operational context without requiring off-chain state.
+
 ## Related Repositories
 
 - `noc-iq-fe` -> frontend application

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Map, Symbol,
-    Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Map, String,
+    Symbol, Vec,
 };
 
 #[contract]
@@ -16,8 +16,11 @@ mod tests;
 // -----------------------------------------------------------------------
 const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
 const OPERATOR_KEY: Symbol = symbol_short!("OPERATOR"); // #28
+const PENDING_ADMIN_KEY: Symbol = symbol_short!("PADMIN"); // #63
+const PENDING_OP_KEY: Symbol = symbol_short!("POP"); // #64
 const CONFIG_KEY: Symbol = symbol_short!("CONFIG");
 const PAUSED_KEY: Symbol = symbol_short!("PAUSED"); // #27
+const PAUSE_INFO_KEY: Symbol = symbol_short!("PAUSEINF"); // #66
 const STATS_KEY: Symbol = symbol_short!("STATS"); // #29
 const HISTORY_KEY: Symbol = symbol_short!("HIST");
 const STORAGE_VERSION_KEY: Symbol = symbol_short!("VER");
@@ -61,6 +64,11 @@ const EVENT_PAUSED: Symbol = symbol_short!("paused"); // #27
 const EVENT_UNPAUSED: Symbol = symbol_short!("unpause"); // #27
 const EVENT_OP_SET: Symbol = symbol_short!("op_set"); // #28
 const EVENT_PRUNED: Symbol = symbol_short!("pruned");
+const EVENT_ADMIN_PROP: Symbol = symbol_short!("adm_prop"); // #63
+const EVENT_ADMIN_ACC: Symbol = symbol_short!("adm_acc"); // #63
+const EVENT_ADMIN_REN: Symbol = symbol_short!("adm_ren"); // #65
+const EVENT_OP_PROP: Symbol = symbol_short!("op_prop"); // #64
+const EVENT_OP_ACC: Symbol = symbol_short!("op_acc"); // #64
 const EVENT_VERSION: Symbol = symbol_short!("v1");
 
 // -----------------------------------------------------------------------
@@ -75,7 +83,8 @@ pub enum SLAError {
     Unauthorized = 3,
     ConfigNotFound = 4,
     VersionMismatch = 5,
-    ContractPaused = 6, // #27
+    ContractPaused = 6,    // #27
+    NoPendingTransfer = 7, // #63 #64
 }
 
 // -----------------------------------------------------------------------
@@ -138,6 +147,14 @@ pub struct SLAStats {
     pub total_violations: u64,
     pub total_rewards: i128,   // sum of all reward amounts paid out
     pub total_penalties: i128, // sum of all penalty amounts (stored positive)
+}
+
+/// #66 – Pause metadata stored when the contract is paused.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseInfo {
+    pub reason: String,
+    pub paused_at: u64, // ledger timestamp (seconds)
 }
 
 // -----------------------------------------------------------------------
@@ -256,28 +273,130 @@ impl SLACalculatorContract {
     }
 
     // -------------------------------------------------------------------
-    // #27 – Pause / Unpause (admin only)
+    // #63 – Two-step admin transfer
     // -------------------------------------------------------------------
 
-    /// Pause the contract; `calculate_sla` will be blocked until unpaused.
+    /// Propose a new admin. The current admin initiates; the new admin must call `accept_admin`.
+    pub fn propose_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+        env.storage().instance().set(&PENDING_ADMIN_KEY, &new_admin);
+        env.events()
+            .publish((EVENT_ADMIN_PROP, EVENT_VERSION, caller), (new_admin,));
+        Ok(())
+    }
+
+    /// Accept a pending admin transfer. Must be called by the proposed new admin.
+    /// On success the caller becomes admin and the pending proposal is cleared.
+    pub fn accept_admin(env: Env, caller: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_ADMIN_KEY)
+            .ok_or(SLAError::NoPendingTransfer)?;
+        if caller != pending {
+            return Err(SLAError::Unauthorized);
+        }
+        env.storage().instance().set(&ADMIN_KEY, &caller);
+        env.storage().instance().remove(&PENDING_ADMIN_KEY);
+        env.events()
+            .publish((EVENT_ADMIN_ACC, EVENT_VERSION, caller), ());
+        Ok(())
+    }
+
+    /// Returns the pending admin address, if any.
+    pub fn get_pending_admin(env: Env) -> Result<Option<Address>, SLAError> {
+        Self::check_version(&env)?;
+        Ok(env.storage().instance().get(&PENDING_ADMIN_KEY))
+    }
+
+    // -------------------------------------------------------------------
+    // #64 – Two-step operator handoff
+    // -------------------------------------------------------------------
+
+    /// Propose a new operator. The current admin initiates; the new operator must call `accept_operator`.
+    pub fn propose_operator(
+        env: Env,
+        caller: Address,
+        new_operator: Address,
+    ) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+        env.storage()
+            .instance()
+            .set(&PENDING_OP_KEY, &new_operator);
+        env.events()
+            .publish((EVENT_OP_PROP, EVENT_VERSION, caller), (new_operator,));
+        Ok(())
+    }
+
+    /// Accept a pending operator handoff. Must be called by the proposed new operator.
+    pub fn accept_operator(env: Env, caller: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&PENDING_OP_KEY)
+            .ok_or(SLAError::NoPendingTransfer)?;
+        if caller != pending {
+            return Err(SLAError::Unauthorized);
+        }
+        env.storage().instance().set(&OPERATOR_KEY, &caller);
+        env.storage().instance().remove(&PENDING_OP_KEY);
+        env.events()
+            .publish((EVENT_OP_ACC, EVENT_VERSION, caller), ());
+        Ok(())
+    }
+
+    /// Returns the pending operator address, if any.
+    pub fn get_pending_operator(env: Env) -> Result<Option<Address>, SLAError> {
+        Self::check_version(&env)?;
+        Ok(env.storage().instance().get(&PENDING_OP_KEY))
+    }
+
+    // -------------------------------------------------------------------
+    // #65 – Admin renounce
+    // -------------------------------------------------------------------
+
+    /// Permanently renounce admin authority. This is irreversible: no admin will
+    /// exist after this call and admin-gated functions will be permanently locked.
+    /// Any pending admin proposal is also cleared.
+    pub fn renounce_admin(env: Env, caller: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+        env.storage().instance().remove(&ADMIN_KEY);
+        env.storage().instance().remove(&PENDING_ADMIN_KEY);
+        env.events()
+            .publish((EVENT_ADMIN_REN, EVENT_VERSION, caller), ());
+        Ok(())
+    }
+
+    /// Pause the contract with a reason and timestamp.
+    /// `calculate_sla` will be blocked until unpaused.
     /// Emits a `paused` event.
-    pub fn pause(env: Env, caller: Address) -> Result<(), SLAError> {
+    pub fn pause(env: Env, caller: Address, reason: String) -> Result<(), SLAError> {
         Self::check_version(&env)?;
         Self::require_admin(&env, &caller)?;
 
+        let paused_at = env.ledger().timestamp();
         env.storage().instance().set(&PAUSED_KEY, &true);
+        env.storage()
+            .instance()
+            .set(&PAUSE_INFO_KEY, &PauseInfo { reason, paused_at });
         env.events()
             .publish((EVENT_PAUSED, EVENT_VERSION, caller), (true,));
         Ok(())
     }
 
-    /// Unpause the contract.
+    /// Unpause the contract. Clears pause metadata.
     /// Emits an `unpause` event.
     pub fn unpause(env: Env, caller: Address) -> Result<(), SLAError> {
         Self::check_version(&env)?;
         Self::require_admin(&env, &caller)?;
 
         env.storage().instance().set(&PAUSED_KEY, &false);
+        env.storage().instance().remove(&PAUSE_INFO_KEY);
         env.events()
             .publish((EVENT_UNPAUSED, EVENT_VERSION, caller), (false,));
         Ok(())
@@ -287,6 +406,12 @@ impl SLACalculatorContract {
     pub fn is_paused(env: Env) -> Result<bool, SLAError> {
         Self::check_version(&env)?;
         Ok(env.storage().instance().get(&PAUSED_KEY).unwrap_or(false))
+    }
+
+    /// Returns pause metadata (reason + timestamp) if currently paused, else None.
+    pub fn get_pause_info(env: Env) -> Result<Option<PauseInfo>, SLAError> {
+        Self::check_version(&env)?;
+        Ok(env.storage().instance().get(&PAUSE_INFO_KEY))
     }
 
     // -------------------------------------------------------------------

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -356,7 +356,7 @@ fn test_contract_starts_unpaused() {
 fn test_admin_can_pause_and_unpause() {
     let (_env, client, actors) = setup();
 
-    client.pause(&actors.admin);
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&_env, "test"));
     assert_eq!(client.is_paused(), true);
 
     client.unpause(&actors.admin);
@@ -366,30 +366,30 @@ fn test_admin_can_pause_and_unpause() {
 #[test]
 #[should_panic]
 fn test_operator_cannot_pause() {
-    let (_env, client, actors) = setup();
-    client.pause(&actors.operator);
+    let (env, client, actors) = setup();
+    client.pause(&actors.operator, &soroban_sdk::String::from_str(&env, "x"));
 }
 
 #[test]
 #[should_panic]
 fn test_stranger_cannot_pause() {
-    let (_env, client, actors) = setup();
-    client.pause(&actors.stranger);
+    let (env, client, actors) = setup();
+    client.pause(&actors.stranger, &soroban_sdk::String::from_str(&env, "x"));
 }
 
 #[test]
 #[should_panic]
 fn test_operator_cannot_unpause() {
-    let (_env, client, actors) = setup();
-    client.pause(&actors.admin);
+    let (env, client, actors) = setup();
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "x"));
     client.unpause(&actors.operator);
 }
 
 #[test]
 #[should_panic]
 fn test_calculate_sla_blocked_when_paused() {
-    let (_env, client, actors) = setup();
-    client.pause(&actors.admin);
+    let (env, client, actors) = setup();
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "maintenance"));
 
     // must panic – ContractPaused
     client.calculate_sla(
@@ -402,9 +402,9 @@ fn test_calculate_sla_blocked_when_paused() {
 
 #[test]
 fn test_calculate_sla_works_after_unpause() {
-    let (_env, client, actors) = setup();
+    let (env, client, actors) = setup();
 
-    client.pause(&actors.admin);
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "x"));
     client.unpause(&actors.admin);
 
     let result = client.calculate_sla(
@@ -755,9 +755,9 @@ fn test_stats_accumulate_across_multiple_calculations() {
 
 #[test]
 fn test_stats_not_updated_on_paused_rejection() {
-    let (_env, client, actors) = setup();
+    let (env, client, actors) = setup();
 
-    client.pause(&actors.admin);
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "test"));
 
     // Fresh setup: verify stats stay at 0 when no successful calls were made.
     let (_env2, client2, _actors2) = setup();
@@ -1193,4 +1193,189 @@ mod snapshots {
             &format!("[{}]", entries.join(",")),
         );
     }
+}
+
+// ============================================================
+// #63 – Two-step admin transfer
+// ============================================================
+
+#[test]
+fn test_propose_and_accept_admin() {
+    let (env, client, actors) = setup();
+    let new_admin = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+    client.accept_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+#[test]
+#[test]
+#[should_panic]
+fn test_old_admin_loses_authority_after_accept() {
+    let (env, client, actors) = setup();
+    let new_admin = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &new_admin);
+    client.accept_admin(&new_admin);
+
+    // old admin can no longer set config – must panic
+    client.set_config(&actors.admin, &symbol_short!("critical"), &20, &200, &1000);
+}
+
+#[test]
+#[should_panic]
+fn test_wrong_address_cannot_accept_admin() {
+    let (env, client, actors) = setup();
+    let new_admin = soroban_sdk::Address::generate(&env);
+    let stranger = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &new_admin);
+    client.accept_admin(&stranger); // must panic
+}
+
+#[test]
+#[should_panic]
+fn test_accept_admin_without_proposal_fails() {
+    let (_env, client, actors) = setup();
+    client.accept_admin(&actors.stranger); // no pending proposal
+}
+
+#[test]
+fn test_get_pending_admin_none_when_no_proposal() {
+    let (_env, client, _actors) = setup();
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+// ============================================================
+// #64 – Two-step operator handoff
+// ============================================================
+
+#[test]
+fn test_propose_and_accept_operator() {
+    let (env, client, actors) = setup();
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    client.propose_operator(&actors.admin, &new_op);
+    assert_eq!(client.get_pending_operator(), Some(new_op.clone()));
+
+    client.accept_operator(&new_op);
+    assert_eq!(client.get_operator(), new_op);
+    assert_eq!(client.get_pending_operator(), None);
+}
+
+#[test]
+#[test]
+#[should_panic]
+fn test_old_operator_locked_out_after_handoff() {
+    let (env, client, actors) = setup();
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    client.propose_operator(&actors.admin, &new_op);
+    client.accept_operator(&new_op);
+
+    // old operator can no longer calculate – must panic
+    client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("HO001"),
+        &symbol_short!("critical"),
+        &5,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_wrong_address_cannot_accept_operator() {
+    let (env, client, actors) = setup();
+    let new_op = soroban_sdk::Address::generate(&env);
+    let stranger = soroban_sdk::Address::generate(&env);
+
+    client.propose_operator(&actors.admin, &new_op);
+    client.accept_operator(&stranger); // must panic
+}
+
+#[test]
+#[should_panic]
+fn test_accept_operator_without_proposal_fails() {
+    let (_env, client, actors) = setup();
+    client.accept_operator(&actors.stranger);
+}
+
+#[test]
+fn test_get_pending_operator_none_when_no_proposal() {
+    let (_env, client, _actors) = setup();
+    assert_eq!(client.get_pending_operator(), None);
+}
+
+// ============================================================
+// #65 – Admin renounce
+// ============================================================
+
+#[test]
+fn test_admin_can_renounce() {
+    let (_env, client, actors) = setup();
+    client.renounce_admin(&actors.admin);
+    // After renounce, admin-gated calls must fail
+}
+
+#[test]
+#[should_panic]
+fn test_admin_gated_call_fails_after_renounce() {
+    let (env, client, actors) = setup();
+    client.renounce_admin(&actors.admin);
+    // set_config must now panic – no admin exists
+    client.set_config(&actors.admin, &symbol_short!("critical"), &20, &200, &1000);
+}
+
+#[test]
+#[should_panic]
+fn test_stranger_cannot_renounce() {
+    let (_env, client, actors) = setup();
+    client.renounce_admin(&actors.stranger);
+}
+
+#[test]
+fn test_renounce_clears_pending_proposal() {
+    let (env, client, actors) = setup();
+    let new_admin = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &new_admin);
+    client.renounce_admin(&actors.admin);
+    assert_eq!(client.get_pending_admin(), None);
+}
+
+// ============================================================
+// #66 – Pause reason + timestamp
+// ============================================================
+
+#[test]
+fn test_pause_stores_reason_and_timestamp() {
+    let (env, client, actors) = setup();
+    let reason = soroban_sdk::String::from_str(&env, "scheduled maintenance");
+
+    client.pause(&actors.admin, &reason);
+
+    let info = client.get_pause_info().expect("pause info should be present");
+    assert_eq!(info.reason, reason);
+    // timestamp is ledger time; just assert it is non-zero in a real ledger,
+    // in test env it defaults to 0 which is still a valid u64
+    let _ = info.paused_at;
+}
+
+#[test]
+fn test_unpause_clears_pause_info() {
+    let (env, client, actors) = setup();
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "reason"));
+    client.unpause(&actors.admin);
+
+    assert_eq!(client.get_pause_info(), None);
+}
+
+#[test]
+fn test_get_pause_info_none_when_not_paused() {
+    let (_env, client, _actors) = setup();
+    assert_eq!(client.get_pause_info(), None);
 }


### PR DESCRIPTION
…a (#63-66)

- #63: propose_admin / accept_admin / get_pending_admin (two-step admin transfer)
- #64: propose_operator / accept_operator / get_pending_operator (two-step operator handoff)
- #65: renounce_admin (irreversible, clears pending proposal) + README governance docs
- #66: pause(reason) stores PauseInfo{reason, paused_at}; get_pause_info(); unpause clears metadata
- Add NoPendingTransfer error variant
- Add PauseInfo contracttype
- Update all existing pause() call sites to pass reason argument
- Add tests for all four issues

closes #63 
closes #64 
closes #65 
closes #66 