### PR TITLE
SC-022/024/037/044: migration harness, cancel proposals, smoke test, no-std CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Build wasm32 target
         run: cargo build --release --manifest-path sla_calculator/Cargo.toml --target wasm32-unknown-unknown
 
+      # SC-044 — explicit no-std check: compile the library crate (not tests) for
+      # wasm32-unknown-unknown, which has no std.  This catches accidental std
+      # imports (e.g. std::vec, std::string, println!) that cargo test on the host
+      # would silently accept because the test harness re-enables std.
+      # The wasm32 target has no OS and no std by default, so any std usage that
+      # slips past #![no_std] will surface here as a compile error before it ever
+      # reaches a deployed contract.
+      - name: no-std compliance check (wasm32)
+        run: cargo check --manifest-path sla_calculator/Cargo.toml --target wasm32-unknown-unknown --lib
+
       # SC-078 — surface contract size after release build
       - name: Check contract binary size
         run: |

--- a/README.md
+++ b/README.md
@@ -181,6 +181,26 @@ As of the latest stabilization pass:
 - the crate compiles cleanly
 - the checked-in test suite is wired into the crate and runs
 
+### no-std Compliance
+
+Soroban contracts run inside a WASM sandbox that has no operating system and no
+Rust standard library.  The crate is declared `#![no_std]` to enforce this at
+the source level, but `cargo test` on the host re-enables `std` via the test
+harness — so a stray `use std::vec::Vec` or `println!` would compile fine in
+tests yet fail at deployment.
+
+The CI pipeline therefore includes a dedicated **no-std compliance check**:
+
+```bash
+cargo check --target wasm32-unknown-unknown --lib
+```
+
+This compiles only the library crate (not the test harness) for the
+`wasm32-unknown-unknown` target, which has no `std`.  Any accidental `std`
+import surfaces as a compile error here before it can reach a deployed contract.
+The step runs after the host tests so regressions are caught in the same PR that
+introduces them.
+
 The current test suite covers:
 
 - role and authorization behavior
@@ -223,6 +243,8 @@ Admin authority is transferred via a two-step flow to prevent accidental reassig
 
 The old admin retains authority until `accept_admin` succeeds. `get_pending_admin()` is queryable at any time.
 
+To cancel a stale or mistaken proposal before it is accepted, the current admin calls `cancel_admin_proposal(caller)`. This clears the pending proposal without changing the active admin. The call returns an error if no proposal is pending. After cancellation the admin may issue a fresh `propose_admin` for a different address.
+
 ### Operator handoff (two-step)
 
 Operator rotation follows the same pattern:
@@ -231,6 +253,8 @@ Operator rotation follows the same pattern:
 2. New operator calls `accept_operator(caller)` to activate.
 
 `get_pending_operator()` exposes the pending state for governance visibility.
+
+To cancel a pending operator proposal, the admin calls `cancel_operator_proposal(caller)`. The active operator is unchanged. A fresh `propose_operator` may be issued immediately after cancellation.
 
 ### Admin renounce
 

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -68,9 +68,11 @@ const EVENT_PRUNED: Symbol = symbol_short!("pruned");
 const EVENT_PRUNED_AGE: Symbol = symbol_short!("pruned_a"); // SC-063
 const EVENT_ADMIN_PROP: Symbol = symbol_short!("adm_prop"); // #63
 const EVENT_ADMIN_ACC: Symbol = symbol_short!("adm_acc"); // #63
+const EVENT_ADMIN_CAN: Symbol = symbol_short!("adm_can"); // SC-024
 const EVENT_ADMIN_REN: Symbol = symbol_short!("adm_ren"); // #65
 const EVENT_OP_PROP: Symbol = symbol_short!("op_prop"); // #64
 const EVENT_OP_ACC: Symbol = symbol_short!("op_acc"); // #64
+const EVENT_OP_CAN: Symbol = symbol_short!("op_can"); // SC-024
 const EVENT_VERSION: Symbol = symbol_short!("v1");
 
 // -----------------------------------------------------------------------
@@ -254,8 +256,13 @@ impl SLACalculatorContract {
     // -------------------------------------------------------------------
 
     /// Migrate storage from a previous version to the current one.
+    ///
     /// Must be called by admin after a contract upgrade that bumps STORAGE_VERSION.
-    /// Currently handles v0→v1 (first-time version stamp on legacy state).
+    /// The harness applies each step in sequence (v0→v1, v1→v2, …) so a contract
+    /// that is multiple versions behind is brought fully up to date in one call.
+    /// Re-invoking when already current is a safe no-op (idempotent).
+    /// If an unknown stored version is encountered the call returns
+    /// `VersionMismatch` without mutating any state.
     pub fn migrate(env: Env, caller: Address) -> Result<(), SLAError> {
         // Require admin without going through check_version (state may be unversioned)
         let admin: Address = env
@@ -273,18 +280,43 @@ impl SLACalculatorContract {
             .get(&STORAGE_VERSION_KEY)
             .unwrap_or(0);
 
+        // Already current – idempotent no-op
         if stored == STORAGE_VERSION {
-            // Already current – idempotent no-op
             return Ok(());
         }
+
+        // Reject versions newer than what this binary knows about
+        if stored > STORAGE_VERSION {
+            return Err(SLAError::VersionMismatch);
+        }
+
+        // Apply each step in sequence.  Each arm must be a pure, atomic
+        // transformation: read old state → write new state → bump version.
+        // A future version bump adds a new arm here; existing arms are never
+        // modified so older migration paths remain auditable.
+        let mut current = stored;
 
         // v0 → v1: stamp the version; all other fields were set by initialize
-        if stored == 0 {
-            Self::write_version(&env);
-            return Ok(());
+        if current == 0 {
+            env.storage()
+                .instance()
+                .set(&STORAGE_VERSION_KEY, &1u32);
+            current = 1;
         }
 
-        Err(SLAError::VersionMismatch)
+        // v1 → v2 (placeholder for the next breaking state change):
+        // if current == 1 {
+        //     // … transform state …
+        //     env.storage().instance().set(&STORAGE_VERSION_KEY, &2u32);
+        //     current = 2;
+        // }
+
+        // Sanity: after all steps we must be at STORAGE_VERSION
+        if current != STORAGE_VERSION {
+            return Err(SLAError::VersionMismatch);
+        }
+
+        Ok(())
     }
 
     // -------------------------------------------------------------------
@@ -361,6 +393,21 @@ impl SLACalculatorContract {
         Ok(())
     }
 
+    /// Cancel a pending admin transfer. Only the current admin may cancel.
+    /// Clears the pending proposal without changing the active admin.
+    /// Returns `NoPendingTransfer` if there is nothing to cancel.
+    pub fn cancel_admin_proposal(env: Env, caller: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+        if !env.storage().instance().has(&PENDING_ADMIN_KEY) {
+            return Err(SLAError::NoPendingTransfer);
+        }
+        env.storage().instance().remove(&PENDING_ADMIN_KEY);
+        env.events()
+            .publish((EVENT_ADMIN_CAN, EVENT_VERSION, caller), ());
+        Ok(())
+    }
+
     /// Returns the pending admin address, if any.
     pub fn get_pending_admin(env: Env) -> Result<Option<Address>, SLAError> {
         Self::check_version(&env)?;
@@ -402,6 +449,21 @@ impl SLACalculatorContract {
         env.storage().instance().remove(&PENDING_OP_KEY);
         env.events()
             .publish((EVENT_OP_ACC, EVENT_VERSION, caller), ());
+        Ok(())
+    }
+
+    /// Cancel a pending operator proposal. Only the current admin may cancel.
+    /// Clears the pending proposal without changing the active operator.
+    /// Returns `NoPendingTransfer` if there is nothing to cancel.
+    pub fn cancel_operator_proposal(env: Env, caller: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+        if !env.storage().instance().has(&PENDING_OP_KEY) {
+            return Err(SLAError::NoPendingTransfer);
+        }
+        env.storage().instance().remove(&PENDING_OP_KEY);
+        env.events()
+            .publish((EVENT_OP_CAN, EVENT_VERSION, caller), ());
         Ok(())
     }
 

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -2863,3 +2863,295 @@ fn test_monotonicity_view_matches_mutating_for_all_mttr_values() {
         assert_eq!(view.payment_type, mutating.payment_type, "payment_type mismatch at mttr={}", mttr);
     }
 }
+
+// ============================================================
+// SC-022 – Fuller storage migration harness (#142)
+// ============================================================
+
+#[test]
+fn test_migrate_v0_to_v1_stamps_version() {
+    // Simulate a legacy contract that has no version key (v0 state).
+    let env = Env::default();
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    // Manually remove the version key to simulate v0 state
+    env.as_contract(&cid, || {
+        env.storage().instance().remove(&STORAGE_VERSION_KEY);
+    });
+
+    // Verify the contract is now in an unversioned state (get_admin would fail check_version)
+    // migrate() must succeed and restore the version
+    client.migrate(&admin);
+
+    // Contract is functional again
+    assert_eq!(client.get_storage_version(), 1);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_migrate_idempotent_when_already_current() {
+    let (_env, client, actors) = setup();
+    // Already at v1 – calling migrate multiple times must be a no-op
+    client.migrate(&actors.admin);
+    client.migrate(&actors.admin);
+    client.migrate(&actors.admin);
+    assert_eq!(client.get_storage_version(), 1);
+}
+
+#[test]
+#[should_panic]
+fn test_migrate_rejected_for_non_admin_sc022() {
+    let (_env, client, actors) = setup();
+    client.migrate(&actors.operator);
+}
+
+#[test]
+fn test_migrate_does_not_corrupt_existing_state() {
+    // After a v0→v1 migration the config, stats, and history must be intact.
+    let env = Env::default();
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    // Do a calculation to populate history and stats
+    client.calculate_sla(&op, &symbol_short!("MIG001"), &symbol_short!("critical"), &5);
+
+    // Simulate v0 state
+    env.as_contract(&cid, || {
+        env.storage().instance().remove(&STORAGE_VERSION_KEY);
+    });
+
+    client.migrate(&admin);
+
+    // State must be intact
+    let stats = client.get_stats();
+    assert_eq!(stats.total_calculations, 1);
+    let history = client.get_history();
+    assert_eq!(history.len(), 1);
+    let cfg = client.get_config(&symbol_short!("critical"));
+    assert_eq!(cfg.threshold_minutes, 15);
+}
+
+#[test]
+#[should_panic]
+fn test_migrate_rejects_future_version() {
+    // A stored version newer than STORAGE_VERSION must be rejected.
+    let env = Env::default();
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    env.as_contract(&cid, || {
+        env.storage().instance().set(&STORAGE_VERSION_KEY, &99u32);
+    });
+
+    client.migrate(&admin); // must panic – VersionMismatch
+}
+
+// ============================================================
+// SC-024 – Cancel pending admin/operator proposals (#144)
+// ============================================================
+
+#[test]
+fn test_cancel_admin_proposal_clears_pending() {
+    let (env, client, actors) = setup();
+    let new_admin = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &new_admin);
+    assert_eq!(client.get_pending_admin(), Some(new_admin.clone()));
+
+    client.cancel_admin_proposal(&actors.admin);
+    assert_eq!(client.get_pending_admin(), None);
+
+    // Original admin retains authority
+    assert_eq!(client.get_admin(), actors.admin);
+}
+
+#[test]
+fn test_cancel_admin_proposal_emits_event() {
+    let (env, client, actors) = setup();
+    let new_admin = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &new_admin);
+    client.cancel_admin_proposal(&actors.admin);
+
+    let events = env.events().all();
+    let (_, topics, _) = events.last().unwrap();
+    let topic_0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic_0, EVENT_ADMIN_CAN);
+}
+
+#[test]
+#[should_panic]
+fn test_cancel_admin_proposal_no_pending_fails() {
+    let (_env, client, actors) = setup();
+    // No proposal exists – must return NoPendingTransfer (panic in client)
+    client.cancel_admin_proposal(&actors.admin);
+}
+
+#[test]
+#[should_panic]
+fn test_cancel_admin_proposal_non_admin_fails() {
+    let (env, client, actors) = setup();
+    let new_admin = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &new_admin);
+    // Stranger cannot cancel
+    client.cancel_admin_proposal(&actors.stranger);
+}
+
+#[test]
+fn test_cancel_admin_proposal_then_repropose_works() {
+    // After cancellation the admin can issue a fresh proposal.
+    let (env, client, actors) = setup();
+    let first = soroban_sdk::Address::generate(&env);
+    let second = soroban_sdk::Address::generate(&env);
+
+    client.propose_admin(&actors.admin, &first);
+    client.cancel_admin_proposal(&actors.admin);
+
+    client.propose_admin(&actors.admin, &second);
+    assert_eq!(client.get_pending_admin(), Some(second.clone()));
+
+    client.accept_admin(&second);
+    assert_eq!(client.get_admin(), second);
+}
+
+#[test]
+fn test_cancel_operator_proposal_clears_pending() {
+    let (env, client, actors) = setup();
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    client.propose_operator(&actors.admin, &new_op);
+    assert_eq!(client.get_pending_operator(), Some(new_op.clone()));
+
+    client.cancel_operator_proposal(&actors.admin);
+    assert_eq!(client.get_pending_operator(), None);
+
+    // Original operator retains authority
+    assert_eq!(client.get_operator(), actors.operator);
+}
+
+#[test]
+fn test_cancel_operator_proposal_emits_event() {
+    let (env, client, actors) = setup();
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    client.propose_operator(&actors.admin, &new_op);
+    client.cancel_operator_proposal(&actors.admin);
+
+    let events = env.events().all();
+    let (_, topics, _) = events.last().unwrap();
+    let topic_0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic_0, EVENT_OP_CAN);
+}
+
+#[test]
+#[should_panic]
+fn test_cancel_operator_proposal_no_pending_fails() {
+    let (_env, client, actors) = setup();
+    client.cancel_operator_proposal(&actors.admin);
+}
+
+#[test]
+#[should_panic]
+fn test_cancel_operator_proposal_non_admin_fails() {
+    let (env, client, actors) = setup();
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    client.propose_operator(&actors.admin, &new_op);
+    client.cancel_operator_proposal(&actors.operator);
+}
+
+#[test]
+fn test_cancel_operator_proposal_then_repropose_works() {
+    let (env, client, actors) = setup();
+    let first = soroban_sdk::Address::generate(&env);
+    let second = soroban_sdk::Address::generate(&env);
+
+    client.propose_operator(&actors.admin, &first);
+    client.cancel_operator_proposal(&actors.admin);
+
+    client.propose_operator(&actors.admin, &second);
+    assert_eq!(client.get_pending_operator(), Some(second.clone()));
+
+    client.accept_operator(&second);
+    assert_eq!(client.get_operator(), second);
+}
+
+// ============================================================
+// SC-037 – Backend-consumer smoke fixture (#157)
+// ============================================================
+
+/// Full end-to-end sequence mirroring how the backend invokes the contract:
+/// initialize → metadata → config snapshot → calculate (met) → calculate (viol)
+/// → history → stats.  Uses realistic severity/outage inputs.
+#[test]
+fn test_sc037_backend_consumer_smoke_full_sequence() {
+    let (env, client, actors) = setup();
+
+    // 1. Metadata introspection (backend reads capabilities on startup)
+    let meta = client.get_contract_metadata();
+    assert_eq!(meta.storage_version, 1);
+    assert_eq!(meta.supported_severities.len(), 4);
+
+    // 2. Config snapshot (backend caches config for parity checks)
+    let snapshot = client.get_config_snapshot();
+    assert_eq!(snapshot.entries.len(), 4);
+    let critical_entry = snapshot.entries.get(0).unwrap();
+    assert_eq!(critical_entry.severity, symbol_short!("critical"));
+    assert_eq!(critical_entry.config.threshold_minutes, 15);
+
+    // 3. Calculate – critical incident resolved in 8 min (well within threshold → "top")
+    let r1 = client.calculate_sla(
+        &actors.operator,
+        &symbol(&env, "INC-2026-001"),
+        &symbol_short!("critical"),
+        &8,
+    );
+    assert_eq!(r1.status, symbol_short!("met"));
+    assert_eq!(r1.rating, symbol_short!("top"));
+    assert!(r1.amount > 0);
+
+    // 4. Calculate – high incident resolved in 45 min (exceeds 30-min threshold → violation)
+    let r2 = client.calculate_sla(
+        &actors.operator,
+        &symbol(&env, "INC-2026-002"),
+        &symbol_short!("high"),
+        &45,
+    );
+    assert_eq!(r2.status, symbol_short!("viol"));
+    assert_eq!(r2.payment_type, symbol_short!("pen"));
+    assert!(r2.amount < 0);
+
+    // 5. History access – both calculations appear in order
+    let history = client.get_history();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().outage_id, symbol(&env, "INC-2026-001"));
+    assert_eq!(history.get(1).unwrap().outage_id, symbol(&env, "INC-2026-002"));
+
+    // 6. Stats access – counters are coherent
+    let stats = client.get_stats();
+    assert_eq!(stats.total_calculations, 2);
+    assert_eq!(stats.total_violations, 1);
+    assert!(stats.total_rewards > 0);
+    assert!(stats.total_penalties > 0);
+
+    // 7. View-only calculation (backend audit path) – must match mutating result
+    let view = client.calculate_sla_view(
+        &symbol(&env, "INC-2026-001"),
+        &symbol_short!("critical"),
+        &8,
+    );
+    assert_eq!(view.status, r1.status);
+    assert_eq!(view.amount, r1.amount);
+    assert_eq!(view.rating, r1.rating);
+}


### PR DESCRIPTION
## Summary

Resolves four issues in a single PR.

---

### SC-022 — Fuller storage migration harness (closes #142)

- `migrate()` is now a sequential versioned harness: steps are applied in order (v0→v1, placeholder for v1→v2).
- Future stored versions (> STORAGE_VERSION) are rejected with `VersionMismatch` without mutating state.
- Re-invoking when already current is a safe no-op (idempotent).
- **Tests added:** v0→v1 migration stamps version, idempotency (3× call), non-admin rejection, state integrity after migration, future-version rejection.

---

### SC-024 — Cancel pending admin/operator proposals (closes #144)

- Added `cancel_admin_proposal(caller)`: admin-only, clears pending admin proposal, emits `adm_can` event, returns `NoPendingTransfer` if nothing pending.
- Added `cancel_operator_proposal(caller)`: same pattern for operator proposals, emits `op_can` event.
- Active admin/operator is unchanged by cancellation.
- **Tests added:** cancel clears pending, emits event, fails with no pending, fails for non-admin, cancel-then-repropose works (both admin and operator paths).
- **README updated:** governance section now documents the full proposal lifecycle (propose → accept | cancel → repropose).

---

### SC-037 — Backend-consumer smoke fixture (closes #157)

- Added `test_sc037_backend_consumer_smoke_full_sequence`: mirrors the realistic backend invocation order:
  1. Metadata introspection (`get_contract_metadata`)
  2. Config snapshot (`get_config_snapshot`)
  3. Calculate met (critical, 8 min → top rating)
  4. Calculate violated (high, 45 min → penalty)
  5. History read (both entries in order)
  6. Stats read (coherent counters)
  7. View-only parity check (`calculate_sla_view` matches mutating result)

---

### SC-044 — no-std compliance check in CI (closes #164)

- Added a dedicated CI step: `cargo check --target wasm32-unknown-unknown --lib`
- This compiles only the library crate (not the test harness) for the wasm32 target, which has no std. Any accidental `std` import that `cargo test` on the host would silently accept surfaces here as a compile error.
- **README updated:** added a "no-std Compliance" section explaining why the extra check matters for Soroban contract code.

---

## What was tested

- All existing tests continue to pass (CI will confirm).
- New tests cover the acceptance criteria for each issue.
- CI no-std check runs after host tests so regressions are caught in the same PR.