### PR TITLE
SC-009/010/012/014: config hash, paginated history, outage query, prune-by-age

### DIFF
--- a/ts/configVersionHash.ts
+++ b/ts/configVersionHash.ts
@@ -1,0 +1,73 @@
+/**
+ * SC-009 — Collision-resistant config version hash (#129)
+ *
+ * Replaces the additive checksum with a djb2-style polynomial hash over a
+ * canonical JSON serialisation of the config snapshot.  Identical snapshots
+ * always produce the same u32 identifier; single-field changes produce a
+ * different value with high probability.
+ *
+ * Backend consumers: compare `versionHash` values to detect config drift.
+ * Do NOT treat the raw number as meaningful — only equality/inequality matters.
+ */
+
+export interface SlaConfig {
+  severity: string;
+  threshold: number;
+  penaltyBps: number;
+  rewardBps: number;
+}
+
+export interface ConfigSnapshot {
+  configs: SlaConfig[];
+  updatedAt: number; // ledger timestamp
+}
+
+/**
+ * Deterministic canonical serialisation — keys sorted, no extra whitespace.
+ */
+function canonicalise(snapshot: ConfigSnapshot): string {
+  const sorted = snapshot.configs
+    .slice()
+    .sort((a, b) => a.severity.localeCompare(b.severity));
+  return JSON.stringify({ configs: sorted, updatedAt: snapshot.updatedAt });
+}
+
+/**
+ * djb2 polynomial hash over UTF-16 code units.
+ * Returns an unsigned 32-bit integer.
+ */
+function djb2(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+/**
+ * Public API — produces a stable, collision-resistant version identifier for
+ * a given config snapshot.
+ */
+export function configVersionHash(snapshot: ConfigSnapshot): number {
+  return djb2(canonicalise(snapshot));
+}
+
+// ---------------------------------------------------------------------------
+// Quick self-test (run with: npx ts-node configVersionHash.ts)
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const snap: ConfigSnapshot = {
+    configs: [
+      { severity: "critical", threshold: 60, penaltyBps: 500, rewardBps: 100 },
+      { severity: "high",     threshold: 120, penaltyBps: 300, rewardBps: 50  },
+    ],
+    updatedAt: 1_000_000,
+  };
+
+  const h1 = configVersionHash(snap);
+  const h2 = configVersionHash({ ...snap, updatedAt: 1_000_001 });
+
+  console.assert(h1 === configVersionHash(snap), "must be deterministic");
+  console.assert(h1 !== h2,                      "must differ on change");
+  console.log("configVersionHash:", h1.toString(16));
+}

--- a/ts/historyByOutage.ts
+++ b/ts/historyByOutage.ts
@@ -1,0 +1,64 @@
+/**
+ * SC-012 — History query by outage identifier (#132)
+ *
+ * Off-chain systems can retrieve all SLA history entries for a specific
+ * outage ID without scanning the full list themselves.
+ *
+ * Behaviour:
+ *   - Returns entries in insertion order (oldest first) — deterministic.
+ *   - Returns an empty array when no entries match (zero-match case).
+ *   - Handles repeated outage IDs correctly (many-match case).
+ */
+
+export interface HistoryEntry {
+  id: string;
+  outageId: string;
+  severity: string;
+  mttr: number;
+  slaMetPct: number;
+  recordedAt: number;
+}
+
+export interface OutageQueryResult {
+  outageId: string;
+  entries: HistoryEntry[];
+  count: number;
+}
+
+/**
+ * Returns all history entries matching `outageId`, preserving insertion order.
+ *
+ * @param history  - full append-only history array
+ * @param outageId - identifier to filter by
+ */
+export function getHistoryByOutage(
+  history: HistoryEntry[],
+  outageId: string,
+): OutageQueryResult {
+  const entries = history.filter((e) => e.outageId === outageId);
+  return { outageId, entries, count: entries.length };
+}
+
+// ---------------------------------------------------------------------------
+// Quick self-test
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const history: HistoryEntry[] = [
+    { id: "e0", outageId: "OUT-1", severity: "critical", mttr: 30,  slaMetPct: 100, recordedAt: 1 },
+    { id: "e1", outageId: "OUT-2", severity: "high",     mttr: 90,  slaMetPct: 80,  recordedAt: 2 },
+    { id: "e2", outageId: "OUT-1", severity: "critical", mttr: 45,  slaMetPct: 100, recordedAt: 3 },
+    { id: "e3", outageId: "OUT-1", severity: "medium",   mttr: 200, slaMetPct: 60,  recordedAt: 4 },
+  ];
+
+  const r0 = getHistoryByOutage(history, "OUT-NONE");
+  console.assert(r0.count === 0, "zero match");
+
+  const r1 = getHistoryByOutage(history, "OUT-2");
+  console.assert(r1.count === 1, "one match");
+
+  const r2 = getHistoryByOutage(history, "OUT-1");
+  console.assert(r2.count === 3, "many matches");
+  console.assert(r2.entries[0].id === "e0", "insertion order preserved");
+
+  console.log("outage query OK — OUT-1 entries:", r2.count);
+}

--- a/ts/historyPagination.ts
+++ b/ts/historyPagination.ts
@@ -1,0 +1,78 @@
+/**
+ * SC-010 — Paginated history read helpers (#130)
+ *
+ * Provides stable, offset-based pagination over an append-only SLA history
+ * array.  Ordering is insertion order (oldest first).
+ *
+ * Cursor semantics:
+ *   - `offset` is the 0-based index of the first record to return.
+ *   - `limit`  is the maximum number of records per page (capped at MAX_PAGE).
+ *   - A page with fewer than `limit` items signals end-of-history.
+ *   - An empty page (offset >= total) is valid and returns [].
+ */
+
+export interface HistoryEntry {
+  id: string;
+  outageId: string;
+  severity: string;
+  mttr: number;
+  slaMetPct: number;
+  recordedAt: number;
+}
+
+export interface HistoryPage {
+  entries: HistoryEntry[];
+  offset: number;
+  total: number;
+  hasMore: boolean;
+}
+
+const MAX_PAGE = 50;
+
+/**
+ * Returns a bounded page of history entries.
+ *
+ * @param history - full append-only history array (oldest first)
+ * @param offset  - 0-based start index
+ * @param limit   - desired page size (clamped to MAX_PAGE)
+ */
+export function getHistoryPage(
+  history: HistoryEntry[],
+  offset: number,
+  limit: number,
+): HistoryPage {
+  const safeOffset = Math.max(0, Math.floor(offset));
+  const safeLimit  = Math.min(MAX_PAGE, Math.max(1, Math.floor(limit)));
+  const slice      = history.slice(safeOffset, safeOffset + safeLimit);
+
+  return {
+    entries: slice,
+    offset:  safeOffset,
+    total:   history.length,
+    hasMore: safeOffset + slice.length < history.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Quick self-test
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const history: HistoryEntry[] = Array.from({ length: 7 }, (_, i) => ({
+    id: `e${i}`, outageId: `o${i % 3}`, severity: "high",
+    mttr: 60, slaMetPct: 100, recordedAt: i,
+  }));
+
+  const p1 = getHistoryPage(history, 0, 3);
+  console.assert(p1.entries.length === 3 && p1.hasMore, "page 1");
+
+  const p2 = getHistoryPage(history, 3, 3);
+  console.assert(p2.entries.length === 3 && p2.hasMore, "page 2");
+
+  const p3 = getHistoryPage(history, 6, 3);
+  console.assert(p3.entries.length === 1 && !p3.hasMore, "last page");
+
+  const p4 = getHistoryPage(history, 99, 3);
+  console.assert(p4.entries.length === 0 && !p4.hasMore, "past end");
+
+  console.log("pagination OK — total:", p1.total);
+}

--- a/ts/historyPruneByAge.ts
+++ b/ts/historyPruneByAge.ts
@@ -1,0 +1,73 @@
+/**
+ * SC-014 — Prune-by-age / pruning-window semantics (#134)
+ *
+ * Extends the existing count-based pruning with an age-oriented strategy.
+ * Operators can prune all entries older than a given ledger timestamp
+ * (absolute cutoff) or keep only entries within a rolling window
+ * (relative to the newest entry).
+ *
+ * Both modes are deterministic: given the same history and parameters
+ * they always produce the same result.
+ */
+
+export interface HistoryEntry {
+  id: string;
+  outageId: string;
+  severity: string;
+  mttr: number;
+  slaMetPct: number;
+  recordedAt: number; // ledger timestamp
+}
+
+export interface PruneResult {
+  kept: HistoryEntry[];
+  pruned: number;
+}
+
+/**
+ * Prune entries with `recordedAt` strictly before `cutoffTimestamp`.
+ */
+export function pruneByAge(
+  history: HistoryEntry[],
+  cutoffTimestamp: number,
+): PruneResult {
+  const kept = history.filter((e) => e.recordedAt >= cutoffTimestamp);
+  return { kept, pruned: history.length - kept.length };
+}
+
+/**
+ * Keep only entries within `windowSize` ledger ticks of the newest entry.
+ * If history is empty the result is an empty array.
+ */
+export function pruneByWindow(
+  history: HistoryEntry[],
+  windowSize: number,
+): PruneResult {
+  if (history.length === 0) return { kept: [], pruned: 0 };
+  const newest  = Math.max(...history.map((e) => e.recordedAt));
+  const cutoff  = newest - windowSize;
+  return pruneByAge(history, cutoff);
+}
+
+// ---------------------------------------------------------------------------
+// Quick self-test
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const history: HistoryEntry[] = [
+    { id: "e0", outageId: "o1", severity: "high", mttr: 60, slaMetPct: 100, recordedAt: 100 },
+    { id: "e1", outageId: "o2", severity: "high", mttr: 60, slaMetPct: 100, recordedAt: 200 },
+    { id: "e2", outageId: "o3", severity: "high", mttr: 60, slaMetPct: 100, recordedAt: 300 },
+  ];
+
+  const r1 = pruneByAge(history, 200);
+  console.assert(r1.pruned === 1 && r1.kept.length === 2, "prune-by-age");
+
+  const r2 = pruneByWindow(history, 150);
+  console.assert(r2.kept.length === 2 && r2.pruned === 1, "prune-by-window");
+
+  const r3 = pruneByWindow([], 100);
+  console.assert(r3.kept.length === 0, "empty history");
+
+  console.log("prune-by-age OK, pruned:", r1.pruned);
+  console.log("prune-by-window OK, kept:", r2.kept.length);
+}


### PR DESCRIPTION
Closes #129, closes #130, closes #132, closes #134

- **#129** — replaces the additive config checksum with a djb2 polynomial hash over a canonical JSON snapshot, making version identifiers collision-resistant.
- **#130** — adds offset/limit pagination over the history array with deterministic ordering and clear end-of-history semantics.
- **#132** — adds a query helper that returns all history entries for a given outage ID in insertion order, covering zero, one, and many matches.
- **#134** — adds `pruneByAge` (absolute cutoff) and `pruneByWindow` (rolling window relative to newest entry) as a second pruning strategy alongside count-based pruning.