### PR TITLE
wasm

### DIFF
--- a/scripts/check-dep-policy.ts
+++ b/scripts/check-dep-policy.ts
@@ -1,0 +1,71 @@
+/**
+ * SC-041: SDK compatibility and dependency update policy enforcer.
+ * Reads Cargo.toml and validates pinned versions against policy rules.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+interface Policy {
+  minSorobanSdk: string;
+  minRustEdition: string;
+  requirePinnedVersions: boolean;
+}
+
+const DEFAULT_POLICY: Policy = {
+  minSorobanSdk: "21.0.0",
+  minRustEdition: "2021",
+  requirePinnedVersions: true,
+};
+
+function parseCargoToml(filePath: string): Record<string, string> {
+  const content = fs.readFileSync(filePath, "utf8");
+  const deps: Record<string, string> = {};
+  const depSection = /\[dependencies\]([\s\S]*?)(\[|$)/.exec(content)?.[1] ?? "";
+  for (const line of depSection.split("\n")) {
+    const m = /^(\S+)\s*=\s*"([^"]+)"/.exec(line.trim());
+    if (m) deps[m[1]] = m[2];
+  }
+  const editionMatch = /edition\s*=\s*"(\d+)"/.exec(content);
+  if (editionMatch) deps["__edition__"] = editionMatch[1];
+  return deps;
+}
+
+function semverAtLeast(actual: string, min: string): boolean {
+  const parse = (v: string) => v.replace(/[^0-9.]/g, "").split(".").map(Number);
+  const [a, b] = [parse(actual), parse(min)];
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] ?? 0) > (b[i] ?? 0)) return true;
+    if ((a[i] ?? 0) < (b[i] ?? 0)) return false;
+  }
+  return true;
+}
+
+function checkPolicy(cargoPath: string, policy: Policy = DEFAULT_POLICY): boolean {
+  const deps = parseCargoToml(cargoPath);
+  let ok = true;
+
+  const sdkVer = deps["soroban-sdk"] ?? "0";
+  if (!semverAtLeast(sdkVer, policy.minSorobanSdk)) {
+    console.error(`❌ soroban-sdk ${sdkVer} < required ${policy.minSorobanSdk}`);
+    ok = false;
+  } else {
+    console.log(`✅ soroban-sdk ${sdkVer} meets minimum ${policy.minSorobanSdk}`);
+  }
+
+  if (policy.requirePinnedVersions) {
+    const unpinned = Object.entries(deps).filter(([k, v]) => k !== "__edition__" && /[\^~*]/.test(v));
+    if (unpinned.length) {
+      console.error(`❌ Unpinned deps: ${unpinned.map(([k]) => k).join(", ")}`);
+      ok = false;
+    } else {
+      console.log("✅ All dependencies are pinned");
+    }
+  }
+
+  return ok;
+}
+
+const cargoPath = path.resolve(process.argv[2] ?? "sla_calculator/Cargo.toml");
+const passed = checkPolicy(cargoPath);
+process.exit(passed ? 0 : 1);

--- a/scripts/check-wasm-size.ts
+++ b/scripts/check-wasm-size.ts
@@ -1,0 +1,62 @@
+/**
+ * SC-042: Enforce contract WASM size budget.
+ * Fails CI if the built WASM exceeds the threshold; prints delta vs baseline.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const WASM_PATH = path.resolve(
+  "sla_calculator/target/wasm32-unknown-unknown/release/sla_calculator.wasm"
+);
+
+// Hard budget in bytes. Raise via PR with documented justification.
+const SIZE_BUDGET_BYTES = 100 * 1024; // 100 KB
+
+// Baseline snapshot file — updated by maintainers on intentional size changes.
+const BASELINE_FILE = path.resolve("sla_calculator/.wasm-size-baseline");
+
+function readBaseline(): number | null {
+  try {
+    return parseInt(fs.readFileSync(BASELINE_FILE, "utf8").trim(), 10);
+  } catch {
+    return null;
+  }
+}
+
+function formatKB(bytes: number): string {
+  return `${(bytes / 1024).toFixed(2)} KB`;
+}
+
+function checkSize(): void {
+  if (!fs.existsSync(WASM_PATH)) {
+    console.error(`❌ WASM not found at ${WASM_PATH}. Run: cargo build --target wasm32-unknown-unknown --release`);
+    process.exit(1);
+  }
+
+  const { size } = fs.statSync(WASM_PATH);
+  const baseline = readBaseline();
+
+  console.log(`WASM size : ${formatKB(size)}`);
+  console.log(`Budget    : ${formatKB(SIZE_BUDGET_BYTES)}`);
+
+  if (baseline !== null) {
+    const delta = size - baseline;
+    const sign = delta >= 0 ? "+" : "";
+    console.log(`Delta vs baseline: ${sign}${formatKB(delta)}`);
+    if (delta > 0) console.warn("⚠️  Size increased since last baseline — update baseline if intentional.");
+  } else {
+    console.log("No baseline found — writing current size as baseline.");
+    fs.writeFileSync(BASELINE_FILE, String(size));
+  }
+
+  if (size > SIZE_BUDGET_BYTES) {
+    console.error(`❌ WASM size ${formatKB(size)} exceeds budget ${formatKB(SIZE_BUDGET_BYTES)}`);
+    console.error("To raise the budget, update SIZE_BUDGET_BYTES in scripts/check-wasm-size.ts with a PR justification.");
+    process.exit(1);
+  }
+
+  console.log("✅ WASM size within budget.");
+}
+
+checkSize();

--- a/scripts/invoke-examples.ts
+++ b/scripts/invoke-examples.ts
@@ -1,0 +1,58 @@
+/**
+ * SC-036: Executable invocation examples for the current contract surface.
+ * Covers governance flows and parity-oriented read flows.
+ */
+
+import { execSync } from "child_process";
+
+const CONTRACT_ID = process.env.CONTRACT_ID ?? "<contract-id>";
+const SOURCE = process.env.SOURCE_ACCOUNT ?? "<source-account>";
+const NETWORK = process.env.NETWORK ?? "testnet";
+
+function invoke(fn: string, args: Record<string, string> = {}): string {
+  const flags = Object.entries(args)
+    .map(([k, v]) => `--${k} ${v}`)
+    .join(" ");
+  const cmd = `soroban contract invoke --id ${CONTRACT_ID} --source-account ${SOURCE} --network ${NETWORK} -- ${fn} ${flags}`;
+  console.log(`\n$ ${cmd}`);
+  try {
+    return execSync(cmd, { encoding: "utf8" });
+  } catch (e: any) {
+    return e.stderr ?? String(e);
+  }
+}
+
+// --- Read flows (parity-oriented) ---
+function readExamples() {
+  console.log("=== Config snapshot ===");
+  console.log(invoke("get_config_snapshot"));
+
+  console.log("=== Stats ===");
+  console.log(invoke("get_stats"));
+
+  console.log("=== Result schema ===");
+  console.log(invoke("get_result_schema"));
+
+  console.log("=== SLA view (critical, 30 min MTTR) ===");
+  console.log(invoke("calculate_sla_view", { severity: "critical", mttr_minutes: "30" }));
+}
+
+// --- Governance flows ---
+function governanceExamples(newAdmin: string, newOperator: string) {
+  console.log("=== Propose admin ===");
+  console.log(invoke("propose_admin", { caller: SOURCE, new_admin: newAdmin }));
+
+  console.log("=== Pending admin ===");
+  console.log(invoke("get_pending_admin"));
+
+  console.log("=== Propose operator ===");
+  console.log(invoke("propose_operator", { caller: SOURCE, new_operator: newOperator }));
+
+  console.log("=== Pending operator ===");
+  console.log(invoke("get_pending_operator"));
+}
+
+const [, , mode, arg1 = "", arg2 = ""] = process.argv;
+if (mode === "read") readExamples();
+else if (mode === "governance") governanceExamples(arg1, arg2);
+else console.log("Usage: ts-node invoke-examples.ts <read|governance> [newAdmin] [newOperator]");

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -1,0 +1,51 @@
+/**
+ * SC-043: Focused test runner for faster local contract test cycles.
+ * Wraps `cargo test` with filter presets so contributors skip unrelated tests.
+ */
+
+import { execSync, ExecSyncOptions } from "child_process";
+
+const PRESETS: Record<string, string> = {
+  governance: "governance",
+  calc:       "calculate_sla",
+  stats:      "stats",
+  pause:      "pause",
+  history:    "history",
+  parity:     "backend_parity",
+  all:        "",
+};
+
+const opts: ExecSyncOptions = { stdio: "inherit", cwd: "sla_calculator" };
+
+function run(filter: string, release: boolean): void {
+  const filterArg = filter ? ` ${filter}` : "";
+  const profile = release ? " --release" : "";
+  const cmd = `cargo test${profile}${filterArg} -- --nocapture`;
+  console.log(`\n$ ${cmd}\n`);
+  execSync(cmd, opts);
+}
+
+function printHelp(): void {
+  console.log("Usage: ts-node run-tests.ts <preset|filter> [--release]");
+  console.log("\nPresets:");
+  for (const [name, filter] of Object.entries(PRESETS)) {
+    console.log(`  ${name.padEnd(12)} → cargo test ${filter || "(all)"}`);
+  }
+  console.log("\nOr pass any string to use as a direct cargo test filter.");
+  console.log("\nExamples:");
+  console.log("  ts-node scripts/run-tests.ts governance");
+  console.log("  ts-node scripts/run-tests.ts parity --release");
+  console.log("  ts-node scripts/run-tests.ts test_pause_blocks_calculate");
+}
+
+const args = process.argv.slice(2);
+if (!args.length || args[0] === "--help") {
+  printHelp();
+  process.exit(0);
+}
+
+const preset = args[0];
+const release = args.includes("--release");
+const filter = PRESETS[preset] !== undefined ? PRESETS[preset] : preset;
+
+run(filter, release);


### PR DESCRIPTION
Closes OpSoll/noc-iq-contracts#156, closes OpSoll/noc-iq-contracts#161, closes OpSoll/noc-iq-contracts#162, closes OpSoll/noc-iq-contracts#163

- **SC-036** (#156): `invoke-examples.ts` — runnable CLI examples for read and governance flows, aligned with current function names.
- **SC-041** (#161): `check-dep-policy.ts` — validates pinned versions and soroban-sdk minimum against documented policy.
- **SC-042** (#162): `check-wasm-size.ts` — enforces a hard WASM size budget with baseline delta tracking; fails CI on breach.
- **SC-043** (#163): `run-tests.ts` — focused test runner with presets (governance, calc, parity, etc.) for faster local iteration.