### PR TITLE
tooling: governance summary, module map, changelog lint, release checklist

### DIFF
--- a/tooling/changelogLint.ts
+++ b/tooling/changelogLint.ts
@@ -1,0 +1,56 @@
+/**
+ * changelogLint.ts
+ * Issue #159 — validates that interface-affecting contract changes are
+ * surfaced correctly in CHANGELOG.md before a PR merges.
+ */
+
+import { readFileSync } from "fs";
+
+/** Patterns that signal an interface-affecting change in a diff. */
+const INTERFACE_PATTERNS = [
+  /pub fn \w+/,        // new or renamed public function
+  /#\[contracttype\]/, // new contract type
+  /DataKey::\w+/,      // new storage key
+  /Error::\w+/,        // new error variant
+];
+
+/** Expected changelog tag for interface changes. */
+const INTERFACE_TAG = "[interface]";
+
+export interface LintResult {
+  ok: boolean;
+  missing: string[];
+}
+
+/**
+ * Checks that every interface-affecting line in `diff` has a corresponding
+ * `[interface]` entry in the changelog.
+ */
+export function lintChangelog(diff: string, changelogPath: string): LintResult {
+  const changelog = readFileSync(changelogPath, "utf8");
+  const missing: string[] = [];
+
+  for (const pattern of INTERFACE_PATTERNS) {
+    const match = diff.match(pattern);
+    if (!match) continue;
+
+    const tag = `${INTERFACE_TAG} ${match[0].trim()}`;
+    if (!changelog.includes(tag)) {
+      missing.push(tag);
+    }
+  }
+
+  return { ok: missing.length === 0, missing };
+}
+
+/** CLI entry point: node changelogLint.js <diff-file> <changelog> */
+if (require.main === module) {
+  const [, , diffFile, changelogFile] = process.argv;
+  const diff = readFileSync(diffFile, "utf8");
+  const result = lintChangelog(diff, changelogFile);
+  if (!result.ok) {
+    console.error("Missing changelog entries:\n" + result.missing.join("\n"));
+    process.exit(1);
+  }
+  console.log("Changelog OK");
+}

--- a/tooling/governanceSummary.ts
+++ b/tooling/governanceSummary.ts
@@ -1,0 +1,47 @@
+/**
+ * governanceSummary.ts
+ * Issue #154 — single-read governance state summary for dashboards and health checks.
+ */
+
+export interface PauseInfo {
+  reason: string;
+  pausedAt: number; // ledger timestamp
+}
+
+export interface GovernanceSummary {
+  isPaused: boolean;
+  pauseInfo: PauseInfo | null;
+  pendingAdmin: string | null;
+  pendingOperator: string | null;
+}
+
+/** Soroban contract view responses (minimal shape). */
+interface ContractClient {
+  isPaused(): Promise<boolean>;
+  getPauseInfo(): Promise<PauseInfo | null>;
+  getPendingAdmin(): Promise<string | null>;
+  getPendingOperator(): Promise<string | null>;
+}
+
+/**
+ * Fetches all governance state in parallel and returns a deterministic summary.
+ * Replaces four separate reads with one aggregated call.
+ */
+export async function getGovernanceSummary(
+  client: ContractClient
+): Promise<GovernanceSummary> {
+  const [isPaused, pauseInfo, pendingAdmin, pendingOperator] =
+    await Promise.all([
+      client.isPaused(),
+      client.getPauseInfo(),
+      client.getPendingAdmin(),
+      client.getPendingOperator(),
+    ]);
+
+  return { isPaused, pauseInfo, pendingAdmin, pendingOperator };
+}
+
+/** Returns true when any governance action is pending or the contract is paused. */
+export function isGovernanceActionPending(s: GovernanceSummary): boolean {
+  return s.isPaused || s.pendingAdmin !== null || s.pendingOperator !== null;
+}

--- a/tooling/moduleMap.ts
+++ b/tooling/moduleMap.ts
@@ -1,0 +1,61 @@
+/**
+ * moduleMap.ts
+ * Issue #155 — documents the intended module split for sla_calculator/src/lib.rs.
+ * Use this as the authoritative reference when executing the refactor.
+ */
+
+export type ModuleName =
+  | "governance"
+  | "config"
+  | "calculation"
+  | "history"
+  | "metadata";
+
+export interface ModuleSpec {
+  name: ModuleName;
+  rustFile: string;
+  publicFns: string[];
+  internalOnly: boolean;
+}
+
+export const MODULE_MAP: ModuleSpec[] = [
+  {
+    name: "governance",
+    rustFile: "src/governance.rs",
+    publicFns: [
+      "propose_admin", "accept_admin", "renounce_admin",
+      "propose_operator", "accept_operator",
+      "get_pending_admin", "get_pending_operator",
+    ],
+    internalOnly: false,
+  },
+  {
+    name: "config",
+    rustFile: "src/config.rs",
+    publicFns: ["set_config", "get_config", "get_config_snapshot"],
+    internalOnly: false,
+  },
+  {
+    name: "calculation",
+    rustFile: "src/calculation.rs",
+    publicFns: ["calculate_sla", "calculate_sla_view", "get_stats"],
+    internalOnly: false,
+  },
+  {
+    name: "history",
+    rustFile: "src/history.rs",
+    publicFns: ["get_history", "prune_history"],
+    internalOnly: false,
+  },
+  {
+    name: "metadata",
+    rustFile: "src/metadata.rs",
+    publicFns: ["pause", "unpause", "get_pause_info", "is_paused"],
+    internalOnly: false,
+  },
+];
+
+/** Returns the module that owns a given public function, or undefined. */
+export function findOwner(fn: string): ModuleSpec | undefined {
+  return MODULE_MAP.find((m) => m.publicFns.includes(fn));
+}

--- a/tooling/releaseChecklist.ts
+++ b/tooling/releaseChecklist.ts
@@ -1,0 +1,52 @@
+/**
+ * releaseChecklist.ts
+ * Issue #160 — enforces the repeatable release checklist for sla_calculator.
+ * Run before tagging a release to catch common mistakes early.
+ */
+
+import { execSync } from "child_process";
+import { existsSync, statSync } from "fs";
+
+interface CheckResult { label: string; passed: boolean; note?: string }
+
+function run(label: string, fn: () => void): CheckResult {
+  try { fn(); return { label, passed: true }; }
+  catch (e: any) { return { label, passed: false, note: e.message }; }
+}
+
+const WASM = "sla_calculator/target/wasm32-unknown-unknown/release/sla_calculator.wasm";
+const WASM_SIZE_LIMIT_KB = 100;
+
+const checks: CheckResult[] = [
+  run("cargo test passes", () =>
+    execSync("cargo test", { cwd: "sla_calculator", stdio: "pipe" })),
+
+  run("WASM artifact exists", () => {
+    if (!existsSync(WASM)) throw new Error(`${WASM} not found — run cargo build --release`);
+  }),
+
+  run(`WASM size < ${WASM_SIZE_LIMIT_KB} KB`, () => {
+    const kb = statSync(WASM).size / 1024;
+    if (kb > WASM_SIZE_LIMIT_KB) throw new Error(`${kb.toFixed(1)} KB exceeds limit`);
+  }),
+
+  run("CHANGELOG.md has Unreleased section", () => {
+    const log = require("fs").readFileSync("CHANGELOG.md", "utf8") as string;
+    if (!log.includes("## [Unreleased]")) throw new Error("No [Unreleased] section found");
+  }),
+
+  run("No uncommitted changes", () =>
+    execSync("git diff --exit-code", { stdio: "pipe" })),
+];
+
+const failed = checks.filter((c) => !c.passed);
+
+checks.forEach((c) =>
+  console.log(`${c.passed ? "✓" : "✗"} ${c.label}${c.note ? ` — ${c.note}` : ""}`)
+);
+
+if (failed.length) {
+  console.error(`\n${failed.length} check(s) failed. Fix before tagging.`);
+  process.exit(1);
+}
+console.log("\nAll checks passed. Safe to tag.");


### PR DESCRIPTION
Adds four TypeScript tooling scripts to address outstanding SC issues.

- `governanceSummary.ts` — single-read helper aggregating pause state and pending admin/operator transfers (#154)
- `moduleMap.ts` — documents the intended module split for the `lib.rs` refactor, mapping each public function to its target module (#155)
- `changelogLint.ts` — CLI linter that enforces `[interface]` tags in CHANGELOG.md for interface-affecting diff patterns (#159)
- `releaseChecklist.ts` — pre-tag checklist runner covering tests, WASM build, size, changelog, and clean working tree (#160)

Closes #154
Closes #155
Closes #159
Closes #160