### PR TITLE
SC-W5-029: add get_version_info endpoint for backend negotiation

### DIFF
--- a/offchain/eventSizeRegression.ts
+++ b/offchain/eventSizeRegression.ts
@@ -1,5 +1,6 @@
 /**
- * SC-017: Event-size regression tests for lifecycle and SLA calculation events.
+ * SC-017 / SC-W5-029: Event-size regression tests for lifecycle, SLA calculation,
+ * and version negotiation events.
  * Catches payload bloat before deployment by asserting max byte sizes per event type.
  */
 
@@ -9,6 +10,7 @@ const EVENT_SIZE_LIMITS: Record<string, number> = {
   contract_unpaused: 80,
   admin_proposed: 120,
   operator_proposed: 120,
+  version_info_read: 96,  // SC-W5-029: version negotiation event must be compact
 };
 
 interface ContractEvent {
@@ -53,8 +55,14 @@ const events: ContractEvent[] = [
     type: "operator_proposed",
     payload: { proposed: "GDEF789", proposer: "GXYZ456" },
   },
+  {
+    // SC-W5-029: version negotiation read is not an emitted event but its
+    // response payload must stay compact for backend startup latency budgets.
+    type: "version_info_read",
+    payload: { storage_version: 1, result_schema_version: 1, needs_migration: false, is_paused: false },
+  },
 ];
 
-console.log("[SC-017] Event-size regression checks:");
+console.log("[SC-017/SC-W5-029] Event-size regression checks:");
 events.forEach(assertEventSize);
 console.log("All event-size checks passed.");

--- a/offchain/governanceConsistency.ts
+++ b/offchain/governanceConsistency.ts
@@ -1,7 +1,10 @@
 /**
- * SC-018: Event-versus-state consistency tests for governance actions.
+ * SC-018 / SC-W5-029: Event-versus-state consistency tests for governance actions
+ * and version negotiation endpoint validation.
+ *
  * Validates that emitted governance events match the resulting stored state
- * for admin, operator, pause, and config actions.
+ * for admin, operator, pause, and config actions. Also validates that
+ * get_version_info returns a consistent snapshot for backend negotiation.
  */
 
 interface GovernanceEvent {
@@ -18,6 +21,14 @@ interface ContractState {
   pauseReason?: string;
 }
 
+interface VersionInfo {
+  storage_version: number;
+  result_schema_version: number;
+  needs_migration: boolean;
+  is_paused: boolean;
+  contract_name: string;
+}
+
 function assertConsistency(
   event: GovernanceEvent,
   state: ContractState,
@@ -31,6 +42,13 @@ function assertConsistency(
     }
   }
   console.log(`  ✓ ${event.action}: event/state consistent`);
+}
+
+function assertVersionInfo(info: VersionInfo): void {
+  if (info.storage_version < 1) throw new Error("[SC-W5-029] storage_version must be >= 1");
+  if (info.result_schema_version < 1) throw new Error("[SC-W5-029] result_schema_version must be >= 1");
+  if (!info.contract_name) throw new Error("[SC-W5-029] contract_name must be non-empty");
+  console.log(`  ✓ version_info: storage_v=${info.storage_version} schema_v=${info.result_schema_version} needs_migration=${info.needs_migration} paused=${info.is_paused}`);
 }
 
 // Simulate governance flows
@@ -61,6 +79,25 @@ const scenarios: Array<{
   },
 ];
 
+// Version negotiation scenarios: paused state must be reflected in version info
+const versionScenarios: Array<{ label: string; info: VersionInfo }> = [
+  {
+    label: "ready contract",
+    info: { storage_version: 1, result_schema_version: 1, needs_migration: false, is_paused: false, contract_name: "sla_calc" },
+  },
+  {
+    label: "paused contract",
+    info: { storage_version: 1, result_schema_version: 1, needs_migration: false, is_paused: true, contract_name: "sla_calc" },
+  },
+];
+
 console.log("[SC-018] Governance event/state consistency checks:");
 scenarios.forEach(({ event, state, checks }) => assertConsistency(event, state, checks));
+
+console.log("[SC-W5-029] Version negotiation consistency checks:");
+versionScenarios.forEach(({ label, info }) => {
+  assertVersionInfo(info);
+  console.log(`  ✓ ${label}: consistent`);
+});
+
 console.log("All consistency checks passed.");

--- a/offchain/readCostRegression.ts
+++ b/offchain/readCostRegression.ts
@@ -1,5 +1,6 @@
 /**
- * SC-016: Read-cost regression tests for history and config-bundle helpers.
+ * SC-016 / SC-W5-029: Read-cost regression tests for history, config-bundle,
+ * and version negotiation helpers.
  * Simulates budget-aware reads against contract view helpers and asserts
  * that response sizes stay within documented thresholds.
  */
@@ -8,6 +9,7 @@ const READ_BUDGET_LIMITS = {
   historyRead: 512,    // bytes
   configBundle: 256,
   metadataRead: 128,
+  versionInfo: 96,     // SC-W5-029: version negotiation must be compact
 };
 
 interface ReadSample {
@@ -49,12 +51,22 @@ const mockMetadataRead = {
   operator: "GABC",
 };
 
+// SC-W5-029: version negotiation response must be compact
+const mockVersionInfo = {
+  storage_version: 1,
+  result_schema_version: 1,
+  needs_migration: false,
+  is_paused: false,
+  contract_name: "sla_calc",
+};
+
 const samples: ReadSample[] = [
   { helper: "historyRead", payload: mockHistoryRead },
   { helper: "configBundle", payload: mockConfigBundle },
   { helper: "metadataRead", payload: mockMetadataRead },
+  { helper: "versionInfo", payload: mockVersionInfo },
 ];
 
-console.log("[SC-016] Read-cost regression checks:");
+console.log("[SC-016/SC-W5-029] Read-cost regression checks:");
 samples.forEach(assertReadBudget);
 console.log("All read-cost checks passed.");

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -194,6 +194,32 @@ pub struct StorageVersionInfo {
     pub needs_migration: bool,
 }
 
+/// SC-W5-029 – Combined version negotiation response for backend startup handshake.
+///
+/// Backend consumers call `get_version_info` once at startup (or after an upgrade)
+/// to determine whether the contract is safe to use. All version-relevant fields
+/// are returned in a single read to minimise round-trips.
+///
+/// Decision logic for backends:
+/// - `needs_migration == true`  → block operations, alert admin to call `migrate`
+/// - `is_paused == true`        → surface pause reason, retry after `unpause`
+/// - `storage_version != result_schema_version` (unexpected) → log and alert
+/// - otherwise                  → contract is ready; proceed normally
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VersionInfo {
+    /// Storage schema version stamped in contract storage.
+    pub storage_version: u32,
+    /// Result schema version for SLAResult field layout.
+    pub result_schema_version: u32,
+    /// True when stored storage version differs from the binary's expected version.
+    pub needs_migration: bool,
+    /// True when the contract is currently paused.
+    pub is_paused: bool,
+    /// Human-readable contract name for log correlation.
+    pub contract_name: Symbol,
+}
+
 // -----------------------------------------------------------------------
 // Contract implementation
 // -----------------------------------------------------------------------
@@ -1213,8 +1239,7 @@ impl SLACalculatorContract {
             .unwrap_or(MAX_HISTORY_SIZE))
     }
 
-    // -------------------------------------------------------------------
-    // SC-021 – Migration state read helper
+    /// SC-021 – Migration state read helper
     // -------------------------------------------------------------------
 
     /// Returns the storage version and migration posture.
@@ -1235,6 +1260,35 @@ impl SLACalculatorContract {
             stored_version,
             expected_version: STORAGE_VERSION,
             needs_migration: stored_version != STORAGE_VERSION,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // SC-W5-029 – Version negotiation endpoint for backend handshake
+    // -------------------------------------------------------------------
+
+    /// Returns a combined version negotiation snapshot for backend startup.
+    ///
+    /// Intentionally bypasses `check_version` so it remains callable even when
+    /// the contract is in a pre-migration state — backends must be able to read
+    /// this before deciding whether to call `migrate`.
+    pub fn get_version_info(env: Env) -> Result<VersionInfo, SLAError> {
+        let stored_version: u32 = env
+            .storage()
+            .instance()
+            .get(&STORAGE_VERSION_KEY)
+            .ok_or(SLAError::NotInitialized)?;
+        let is_paused: bool = env
+            .storage()
+            .instance()
+            .get(&PAUSED_KEY)
+            .unwrap_or(false);
+        Ok(VersionInfo {
+            storage_version: stored_version,
+            result_schema_version: RESULT_SCHEMA_VERSION,
+            needs_migration: stored_version != STORAGE_VERSION,
+            is_paused,
+            contract_name: symbol_short!("sla_calc"),
         })
     }
 }

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -3223,3 +3223,75 @@ fn test_event_replay_after_prune_history_page_reflects_pruned_state() {
         assert_eq!(history.get(i).unwrap().outage_id, symbol(&env, "NEW"));
     }
 }
+
+// ============================================================
+// SC-W5-029 – Version negotiation endpoint tests
+// ============================================================
+
+#[test]
+fn test_get_version_info_returns_correct_versions_after_init() {
+    let (_env, client, _actors) = setup();
+    let info = client.get_version_info();
+    assert_eq!(info.storage_version, 1);
+    assert_eq!(info.result_schema_version, 1);
+    assert!(!info.needs_migration);
+    assert!(!info.is_paused);
+    assert_eq!(info.contract_name, symbol_short!("sla_calc"));
+}
+
+#[test]
+fn test_get_version_info_reflects_paused_state() {
+    let (env, client, actors) = setup();
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "upgrade"));
+    let info = client.get_version_info();
+    assert!(info.is_paused);
+    assert!(!info.needs_migration);
+}
+
+#[test]
+fn test_get_version_info_reflects_unpaused_state() {
+    let (env, client, actors) = setup();
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "test"));
+    client.unpause(&actors.admin);
+    let info = client.get_version_info();
+    assert!(!info.is_paused);
+}
+
+#[test]
+fn test_get_version_info_is_deterministic_across_repeated_calls() {
+    let (_env, client, _actors) = setup();
+    let a = client.get_version_info();
+    let b = client.get_version_info();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn test_get_version_info_not_affected_by_sla_calculations() {
+    let (_env, client, actors) = setup();
+    let before = client.get_version_info();
+    client.calculate_sla(&actors.operator, &symbol_short!("OUT1"), &symbol_short!("high"), &10);
+    client.calculate_sla(&actors.operator, &symbol_short!("OUT2"), &symbol_short!("critical"), &20);
+    let after = client.get_version_info();
+    assert_eq!(before.storage_version, after.storage_version);
+    assert_eq!(before.result_schema_version, after.result_schema_version);
+    assert_eq!(before.needs_migration, after.needs_migration);
+}
+
+#[test]
+#[should_panic]
+fn test_get_version_info_panics_when_not_initialized() {
+    let env = Env::default();
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    // No initialize call — must panic (NotInitialized)
+    client.get_version_info();
+}
+
+#[test]
+fn test_get_version_info_needs_migration_false_after_migrate() {
+    let (_env, client, actors) = setup();
+    // migrate on an already-current contract is a no-op; needs_migration stays false
+    client.migrate(&actors.admin);
+    let info = client.get_version_info();
+    assert!(!info.needs_migration);
+}


### PR DESCRIPTION
- Add VersionInfo contracttype combining storage_version, result_schema_version, needs_migration, is_paused, and contract_name in a single read
- Add get_version_info() bypassing check_version so it's callable pre-migration
- Add 7 tests: happy path, paused/unpaused reflection, determinism, calc invariance, uninitialized panic, and post-migrate state
- Extend offchain helpers (governanceConsistency, readCostRegression, eventSizeRegression) with SC-W5-029 version negotiation coverage

Closes #230
Closes #231
Closes #232
Closes #233