### PR TITLE
Replay-Safe SLA Ledger: Deterministic Idempotency + Saturating Monetary Math

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -760,7 +760,6 @@ impl SLACalculatorContract {
             mttr_minutes,
             &cfg,
             config_version_hash,
-            0,
             env.ledger().timestamp(),
         ))
     }
@@ -794,6 +793,17 @@ impl SLACalculatorContract {
             .instance()
             .get(&HISTORY_KEY)
             .unwrap_or_else(|| Vec::new(&env));
+
+        let mut existing: Option<SLAResult> = None;
+        for i in 0..history.len() {
+            let entry = history.get(i).unwrap();
+            if entry.outage_id == outage_id {
+                existing = Some(entry);
+            }
+        }
+        if let Some(prev) = existing {
+            return Ok(prev);
+        }
 
         history.push_back(result.clone());
 
@@ -850,7 +860,7 @@ impl SLACalculatorContract {
         // Case 1: SLA violated → penalty
         if mttr_minutes > threshold {
             let overtime = (mttr_minutes - threshold) as i128;
-            let penalty = overtime * cfg.penalty_per_minute;
+            let penalty = overtime.saturating_mul(cfg.penalty_per_minute);
 
             SLAResult {
                 outage_id,
@@ -879,7 +889,10 @@ impl SLACalculatorContract {
                 (100u32, symbol_short!("good"))
             };
 
-            let reward = (cfg.reward_base * multiplier as i128) / 100;
+            let reward = cfg
+                .reward_base
+                .saturating_mul(multiplier as i128)
+                .div_euclid(100);
 
             SLAResult {
                 outage_id,
@@ -1108,13 +1121,13 @@ impl SLACalculatorContract {
                 total_penalties: 0,
             });
 
-        stats.total_calculations += 1;
+        stats.total_calculations = stats.total_calculations.saturating_add(1);
 
         if met {
-            stats.total_rewards += reward;
+            stats.total_rewards = stats.total_rewards.saturating_add(reward);
         } else {
-            stats.total_violations += 1;
-            stats.total_penalties += penalty;
+            stats.total_violations = stats.total_violations.saturating_add(1);
+            stats.total_penalties = stats.total_penalties.saturating_add(penalty);
         }
 
         env.storage().instance().set(&STATS_KEY, &stats);


### PR DESCRIPTION
## Summary
This PR applies a minimal hardening patch to make SLA execution replay-safe and payment arithmetic resilient under extreme inputs, while preserving existing behavior for normal flows.

### What changed
- Added idempotent replay guard in `calculate_sla`:
  - repeated submissions for the same `outage_id` now return the existing latest result
  - no duplicate history append, no duplicate stats mutation, no duplicate event emission
- Hardened arithmetic in result + stats paths:
  - replaced risky multiplication/addition with saturating operations
  - normalized reward division using deterministic Euclidean division
- Fixed audit/view calculation call path argument mismatch to keep deterministic parity and build correctness

### Why this closes the assigned issues
- Closes replay/idempotency invariants and repeated-submission history behavior
- Closes sequence/replay safety expectations by making repeated backend submits no-op deterministic
- Closes overflow hardening for penalty/reward/stat aggregation at extreme input ranges
- Closes payout rounding consistency via canonical integer division semantics

## Verification
- `cargo test` could not be run in this environment because Rust/Cargo is not installed here.
- Patch was validated by static inspection against existing replay, event-state, and extreme-value test intent already present in the repository.

Closes #210
Closes #211
Closes #212
Closes #213
