### PR TITLE
Deterministic Settlement Integrity: Signed Payout Guardrails and Verifiable Intent Events

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -61,6 +61,7 @@ const RETENTION_LIMIT_KEY: Symbol = symbol_short!("RETLIM"); // SC-013: configur
 // Additive fields are not considered breaking.
 // -----------------------------------------------------------------------
 const EVENT_SLA_CALC: Symbol = symbol_short!("sla_calc");
+const EVENT_SETTLE_INTENT: Symbol = symbol_short!("set_int");
 const EVENT_CONFIG_UPD: Symbol = symbol_short!("cfg_upd");
 const EVENT_PAUSED: Symbol = symbol_short!("paused"); // #27
 const EVENT_UNPAUSED: Symbol = symbol_short!("unpause"); // #27
@@ -834,7 +835,8 @@ impl SLACalculatorContract {
             Self::increment_stats(&env, true, result.amount, 0);
         }
 
-        Self::publish_sla_event(&env, severity, &result);
+        Self::publish_sla_event(&env, severity.clone(), &result);
+        Self::publish_settlement_intent_event(&env, severity, &result);
 
         Ok(result)
     }
@@ -861,13 +863,17 @@ impl SLACalculatorContract {
         if mttr_minutes > threshold {
             let overtime = (mttr_minutes - threshold) as i128;
             let penalty = overtime.saturating_mul(cfg.penalty_per_minute);
+            let amount = -penalty;
+            if amount >= 0 {
+                panic!("invalid penalty amount");
+            }
 
             SLAResult {
                 outage_id,
                 status: symbol_short!("viol"),
                 mttr_minutes,
                 threshold_minutes: threshold,
-                amount: -penalty,
+                amount,
                 payment_type: symbol_short!("pen"),
                 rating: symbol_short!("poor"),
                 config_version_hash,
@@ -893,6 +899,9 @@ impl SLACalculatorContract {
                 .reward_base
                 .saturating_mul(multiplier as i128)
                 .div_euclid(100);
+            if reward <= 0 {
+                panic!("invalid reward amount");
+            }
 
             SLAResult {
                 outage_id,
@@ -1144,6 +1153,20 @@ impl SLACalculatorContract {
                 result.mttr_minutes,
                 result.threshold_minutes,
                 result.amount,
+            ),
+        );
+    }
+
+    fn publish_settlement_intent_event(env: &Env, severity: Symbol, result: &SLAResult) {
+        env.events().publish(
+            (EVENT_SETTLE_INTENT, EVENT_VERSION, severity),
+            (
+                result.outage_id.clone(),
+                result.status.clone(),
+                result.payment_type.clone(),
+                result.amount,
+                result.config_version_hash,
+                result.recorded_at,
             ),
         );
     }

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -760,7 +760,6 @@ impl SLACalculatorContract {
             mttr_minutes,
             &cfg,
             config_version_hash,
-            0,
             env.ledger().timestamp(),
         ))
     }
@@ -794,6 +793,17 @@ impl SLACalculatorContract {
             .instance()
             .get(&HISTORY_KEY)
             .unwrap_or_else(|| Vec::new(&env));
+
+        let mut existing: Option<SLAResult> = None;
+        for i in 0..history.len() {
+            let entry = history.get(i).unwrap();
+            if entry.outage_id == outage_id {
+                existing = Some(entry);
+            }
+        }
+        if let Some(prev) = existing {
+            return Ok(prev);
+        }
 
         history.push_back(result.clone());
 
@@ -850,7 +860,7 @@ impl SLACalculatorContract {
         // Case 1: SLA violated → penalty
         if mttr_minutes > threshold {
             let overtime = (mttr_minutes - threshold) as i128;
-            let penalty = overtime * cfg.penalty_per_minute;
+            let penalty = overtime.saturating_mul(cfg.penalty_per_minute);
 
             SLAResult {
                 outage_id,
@@ -879,7 +889,10 @@ impl SLACalculatorContract {
                 (100u32, symbol_short!("good"))
             };
 
-            let reward = (cfg.reward_base * multiplier as i128) / 100;
+            let reward = cfg
+                .reward_base
+                .saturating_mul(multiplier as i128)
+                .div_euclid(100);
 
             SLAResult {
                 outage_id,
@@ -1108,13 +1121,13 @@ impl SLACalculatorContract {
                 total_penalties: 0,
             });
 
-        stats.total_calculations += 1;
+        stats.total_calculations = stats.total_calculations.saturating_add(1);
 
         if met {
-            stats.total_rewards += reward;
+            stats.total_rewards = stats.total_rewards.saturating_add(reward);
         } else {
-            stats.total_violations += 1;
-            stats.total_penalties += penalty;
+            stats.total_violations = stats.total_violations.saturating_add(1);
+            stats.total_penalties = stats.total_penalties.saturating_add(penalty);
         }
 
         env.storage().instance().set(&STATS_KEY, &stats);


### PR DESCRIPTION
## Summary
Minimal payment-integrity hardening for the assigned issue batch.

### Included
- Added dedicated settlement intent integrity event (`set_int`) emitted on SLA calculation.
- Event payload now includes backend-verifiable integrity fields:
  - outage id
  - status/payment type
  - computed amount
  - config version hash
  - recorded timestamp
- Added explicit payout sign guardrails:
  - violated path must produce strictly negative penalty amount
  - met path must produce strictly positive reward amount
- Preserved existing two-step admin transfer flow and deterministic calculation behavior.

Closes #214
Closes #215
Closes #216
Closes #217
