### PR TITLE
Record pause actor provenance in SLA pause metadata

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -185,6 +185,7 @@ pub struct SLAStats {
 pub struct PauseInfo {
     pub reason: String,
     pub paused_at: u64, // ledger timestamp (seconds)
+    pub paused_by: Address,
 }
 
 /// SC-021 – Storage version and migration posture for off-chain consumers.
@@ -580,7 +581,14 @@ impl SLACalculatorContract {
         env.storage().instance().set(&PAUSED_KEY, &true);
         env.storage()
             .instance()
-            .set(&PAUSE_INFO_KEY, &PauseInfo { reason, paused_at });
+            .set(
+                &PAUSE_INFO_KEY,
+                &PauseInfo {
+                    reason,
+                    paused_at,
+                    paused_by: caller.clone(),
+                },
+            );
         env.events()
             .publish((EVENT_PAUSED, EVENT_VERSION, caller), (true,));
         Ok(())

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -1915,6 +1915,7 @@ fn test_pause_stores_reason_and_timestamp() {
         .get_pause_info()
         .expect("pause info should be present");
     assert_eq!(info.reason, reason);
+    assert_eq!(info.paused_by, actors.admin);
     // timestamp is ledger time; just assert it is non-zero in a real ledger,
     // in test env it defaults to 0 which is still a valid u64
     let _ = info.paused_at;


### PR DESCRIPTION
Adds the pausing actor to the stored pause metadata so recovery and backend workflows can deterministically inspect who paused the contract.

Closes #223.

Summary:
- extends PauseInfo with paused_by
- stores the admin address during pause
- adds a regression test asserting the stored provenance matches the pausing admin