### PR TITLE
Feat/parameter

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -1159,10 +1159,12 @@ impl SLACalculatorContract {
 
     /// #70 – Validates configuration parameters to ensure safe and meaningful values.
     fn validate_config(
+        env: &Env,
         severity: &Symbol,
         threshold_minutes: u32,
         penalty_per_minute: i128,
         reward_base: i128,
+        existing_configs: &Map<Symbol, SLAConfig>,
     ) -> Result<(), SLAError> {
         // Validate severity is one of the supported values
         if !Self::is_canonical_severity(severity) {
@@ -1216,6 +1218,42 @@ impl SLACalculatorContract {
             }
         } else {
             return Err(SLAError::InvalidSeverity);
+        }
+
+        // Cross-severity monotonicity validation
+        let severities = Self::canonical_severities(env); // order: critical, high, medium, low
+        
+        // Get the index of the severity being updated
+        let current_index = Self::canonical_severity_index(severity).unwrap();
+        
+        // Validate against all other severities to maintain proper ordering
+        for (i, other_severity) in severities.iter().enumerate() {
+            if other_severity == *severity {
+                continue;
+            }
+            
+            let other_config = existing_configs.get(&other_severity).unwrap();
+            
+            // For any severity that comes before the current one (lower index = higher severity)
+            if i < current_index {
+                // Higher severity should have lower threshold than current
+                if threshold_minutes <= other_config.threshold_minutes {
+                    return Err(SLAError::InvalidThreshold);
+                }
+                // Higher severity should have higher penalty than current
+                if penalty_per_minute >= other_config.penalty_per_minute {
+                    return Err(SLAError::InvalidPenalty);
+                }
+            } else {
+                // Lower severity should have higher threshold than current
+                if threshold_minutes >= other_config.threshold_minutes {
+                    return Err(SLAError::InvalidThreshold);
+                }
+                // Lower severity should have lower penalty than current
+                if penalty_per_minute <= other_config.penalty_per_minute {
+                    return Err(SLAError::InvalidPenalty);
+                }
+            }
         }
 
         Ok(())

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -660,19 +660,22 @@ impl SLACalculatorContract {
         Self::check_version(&env)?;
         Self::require_admin(&env, &caller)?; // #28 – admin role enforced
 
-        // #70 – Validate configuration parameters
-        Self::validate_config(
-            &severity,
-            threshold_minutes,
-            penalty_per_minute,
-            reward_base,
-        )?;
-
+        // Load existing configs first to validate against
         let mut configs: Map<Symbol, SLAConfig> = env
             .storage()
             .instance()
             .get(&CONFIG_KEY)
             .ok_or(SLAError::NotInitialized)?;
+
+        // #70 – Validate configuration parameters, including cross-severity relationships
+        Self::validate_config(
+            &env,
+            &severity,
+            threshold_minutes,
+            penalty_per_minute,
+            reward_base,
+            &configs,
+        )?;
 
         configs.set(
             severity.clone(),

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -5080,6 +5080,102 @@ fn test_set_config_rejects_threshold_zero_for_low() {
     client.set_config(&actors.admin, &symbol_short!("low"), &0, &10, &600);
 }
 
+// --- Cross-severity monotonicity rejections ---
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_critical_threshold_greater_than_high() {
+    // Critical threshold (31) > high threshold (30 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("critical"), &31, &100, &750);
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_high_threshold_greater_than_medium() {
+    // High threshold (61) > medium threshold (60 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("high"), &61, &50, &750);
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_medium_threshold_greater_than_low() {
+    // Medium threshold (121) > low threshold (120 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("medium"), &121, &25, &750);
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_low_penalty_greater_than_medium() {
+    // Low penalty (26) > medium penalty (25 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("low"), &120, &26, &600);
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_medium_penalty_greater_than_high() {
+    // Medium penalty (51) > high penalty (50 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("medium"), &60, &51, &750);
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_high_penalty_greater_than_critical() {
+    // High penalty (101) > critical penalty (100 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("high"), &30, &101, &750);
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_high_threshold_less_than_critical() {
+    // High threshold (14) < critical threshold (15 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("high"), &14, &50, &750);
+}
+
+#[test]
+#[should_panic]
+fn test_set_config_rejects_critical_penalty_less_than_high() {
+    // Critical penalty (49) < high penalty (50 default) - should be rejected
+    let (_env, client, actors) = setup();
+    client.set_config(&actors.admin, &symbol_short!("critical"), &15, &49, &750);
+}
+
+#[test]
+fn test_set_config_accepts_valid_cross_severity_updates() {
+    // Valid updates that maintain monotonicity should be accepted
+    let (_env, client, actors) = setup();
+    
+    // Update critical first (valid values)
+    client.set_config(&actors.admin, &symbol_short!("critical"), &20, &100, &750);
+    // Then update high (must be > critical threshold 20 and < critical penalty 100)
+    client.set_config(&actors.admin, &symbol_short!("high"), &40, &50, &750);
+    // Then update medium (must be > high threshold 40 and < high penalty 50)
+    client.set_config(&actors.admin, &symbol_short!("medium"), &80, &25, &750);
+    // Then update low (must be > medium threshold 80 and < medium penalty 25)
+    client.set_config(&actors.admin, &symbol_short!("low"), &160, &10, &600);
+    
+    // Verify all values were set correctly
+    let critical = client.get_config(&symbol_short!("critical"));
+    let high = client.get_config(&symbol_short!("high"));
+    let medium = client.get_config(&symbol_short!("medium"));
+    let low = client.get_config(&symbol_short!("low"));
+    
+    assert_eq!(critical.threshold_minutes, 20);
+    assert_eq!(critical.penalty_per_minute, 100);
+    assert_eq!(high.threshold_minutes, 40);
+    assert_eq!(high.penalty_per_minute, 50);
+    assert_eq!(medium.threshold_minutes, 80);
+    assert_eq!(medium.penalty_per_minute, 25);
+    assert_eq!(low.threshold_minutes, 160);
+    assert_eq!(low.penalty_per_minute, 10);
+}
+
 // ============================================================
 // SC-W5-049 (#250) – Failure-class mapping: retryable vs terminal errors
 //


### PR DESCRIPTION
1. **Updated validate_config to check cross-severity relationships**: I modified the `validate_config` function to accept the existing configs and environment, then added cross-severity validation that ensures:
   - Thresholds are strictly increasing: critical < high < medium < low
   - Penalties are strictly decreasing: critical > high > medium > low

closes #454

2. **Return the correct error types**: When cross-severity constraints are violated, it returns `SLAError::InvalidThreshold` for threshold violations and `SLAError::InvalidPenalty` for penalty violations, which matches the requirements.

closes #456

4. **Added comprehensive test cases**: I added 10 new test cases that cover:
   - All the specific cases mentioned in the problem statement (critical threshold > high threshold, low penalty > medium penalty)
   - All other cross-severity violations
   - A positive test case that verifies valid updates are still accepted

closes #459

The changes I made ensure that admins can no longer configure invalid cross-severity relationships, which was the main issue described in the problem. The validation now properly enforces that thresholds and penalties maintain logical monotonicity across all severity levels.

closes #465