### PR TITLE
Feat/concurrency

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -486,25 +486,38 @@ impl SLACalculatorContract {
     // -------------------------------------------------------------------
 
     /// Propose a new admin. The current admin initiates; the new admin must call `accept_admin`.
+    /// Proposals expire after 7 days.
     pub fn propose_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), SLAError> {
         Self::check_version(&env)?;
         Self::require_admin(&env, &caller)?;
-        env.storage().instance().set(&PENDING_ADMIN_KEY, &new_admin);
+        let proposal = PendingProposalInfo {
+            target: new_admin.clone(),
+            proposed_at: env.ledger().timestamp(),
+        };
+        env.storage().instance().set(&PENDING_ADMIN_KEY, &proposal);
         env.events()
             .publish((EVENT_ADMIN_PROP, EVENT_VERSION, caller), (new_admin,));
         Ok(())
     }
 
     /// Accept a pending admin transfer. Must be called by the proposed new admin.
-    /// On success the caller becomes admin and the pending proposal is cleared.
+    /// Proposals expire after 7 days.
     pub fn accept_admin(env: Env, caller: Address) -> Result<(), SLAError> {
         Self::check_version(&env)?;
-        let pending: Address = env
+        let pending: PendingProposalInfo = env
             .storage()
             .instance()
             .get(&PENDING_ADMIN_KEY)
             .ok_or(SLAError::NoPendingTransfer)?;
-        if caller != pending {
+            
+        // Check if proposal has expired
+        let now = env.ledger().timestamp();
+        if now - pending.proposed_at > PROPOSAL_EXPIRATION_SECONDS {
+            env.storage().instance().remove(&PENDING_ADMIN_KEY);
+            return Err(SLAError::NoPendingTransfer);
+        }
+        
+        if caller != pending.target {
             return Err(SLAError::Unauthorized);
         }
         env.storage().instance().set(&ADMIN_KEY, &caller);

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -973,6 +973,17 @@ impl SLACalculatorContract {
         Ok((summary, results))
     }
 
+    /// Calculate SLA for multiple outages in a single transaction (operator only).
+    /// Processes each item in the batch sequentially. Failed items do not
+    /// halt the batch; they are recorded as failures in the results.
+    pub fn batch_calculate(
+        env: Env,
+        caller: Address,
+        requests: soroban_sdk::Vec<crate::batch::BatchRequest>,
+    ) -> Result<(crate::batch::BatchSummary, soroban_sdk::Vec<crate::batch::BatchResult>), SLAError> {
+        crate::batch::batch_calculate(&env, &caller, requests)
+    }
+
     // -------------------------------------------------------------------
     // SLA calculation (operator only)                                #28
     // -------------------------------------------------------------------

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -902,6 +902,77 @@ impl SLACalculatorContract {
         )
     }
 
+    /// Recalculates SLA for multiple outages in a single transaction without mutating any state.
+    /// Can be called by anyone for verification and audit purposes.
+    pub fn batch_calculate_view(
+        env: Env,
+        requests: soroban_sdk::Vec<crate::batch::BatchRequest>,
+    ) -> Result<(crate::batch::BatchSummary, soroban_sdk::Vec<crate::batch::BatchResult>), SLAError> {
+        Self::check_version(&env)?;
+        // Validate batch inputs before processing
+        crate::batch::validate_batch(&env, &requests)?;
+        
+        // Bypass all authorization and pause checks to allow public verification
+        let configs: soroban_sdk::Map<Symbol, SLAConfig> = env
+            .storage()
+            .instance()
+            .get(&CONFIG_KEY)
+            .ok_or(SLAError::NotInitialized)?;
+
+        let mut results = soroban_sdk::Vec::new(&env);
+        let mut succeeded: u32 = 0;
+        let mut failed: u32 = 0;
+        let mut total_rewards: i128 = 0;
+        let mut total_penalties: i128 = 0;
+
+        for i in 0..requests.len() {
+            let req = requests.get(i).unwrap();
+
+            // Try to calculate (no persistence, pure computation only)
+            match crate::batch::process_single(&env, &configs, &req) {
+                Ok(result) => {
+                    succeeded = succeeded.saturating_add(1);
+                    if result.status == symbol_short!("viol") {
+                        total_penalties = total_penalties.saturating_add(result.amount);
+                    } else {
+                        total_rewards = total_rewards.saturating_add(result.amount);
+                    }
+                    results.push_back(crate::batch::BatchResult {
+                        outage_id: req.outage_id,
+                        success: true,
+                        result: Some(result),
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    failed = failed.saturating_add(1);
+                    let error_msg = match e {
+                        SLAError::ConfigNotFound => symbol_short!("no_config"),
+                        SLAError::InvalidSeverity => symbol_short!("bad_sev"),
+                        SLAError::InvalidThreshold => symbol_short!("bad_thresh"),
+                        _ => symbol_short!("unknown"),
+                    };
+                    results.push_back(crate::batch::BatchResult {
+                        outage_id: req.outage_id,
+                        success: false,
+                        result: None,
+                        error: Some(error_msg),
+                    });
+                }
+            }
+        }
+
+        let summary = crate::batch::BatchSummary {
+            total: requests.len(),
+            succeeded,
+            failed,
+            total_rewards,
+            total_penalties,
+        };
+
+        Ok((summary, results))
+    }
+
     // -------------------------------------------------------------------
     // SLA calculation (operator only)                                #28
     // -------------------------------------------------------------------

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -36,6 +36,7 @@ const STORAGE_VERSION: u32 = 1;
 const RESULT_SCHEMA_VERSION: u32 = 1;
 const MAX_HISTORY_SIZE: u32 = 1000; // SC-062: bounded retention cap
 const RETENTION_LIMIT_KEY: Symbol = symbol_short!("RETLIM"); // SC-013: configurable retention
+const PROPOSAL_EXPIRATION_SECONDS: u64 = 604800; // 7 days in seconds
 
 // -----------------------------------------------------------------------
 // Events
@@ -215,6 +216,15 @@ pub struct PauseInfo {
     pub reason: String,
     pub paused_at: u64, // ledger timestamp (seconds)
     pub paused_by: Address,
+}
+
+/// Pending governance proposal with timestamp for expiration tracking.
+/// Stores the target address and when the proposal was created.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingProposalInfo {
+    pub target: Address,
+    pub proposed_at: u64, // ledger timestamp (seconds) when proposal was created
 }
 
 /// SC-021 – Storage version and migration posture for off-chain consumers.

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -542,10 +542,20 @@ impl SLACalculatorContract {
         Ok(())
     }
 
-    /// Returns the pending admin address, if any.
+    /// Returns the pending admin address, if any (only returns if proposal is still valid).
     pub fn get_pending_admin(env: Env) -> Result<Option<Address>, SLAError> {
         Self::check_version(&env)?;
-        Ok(env.storage().instance().get(&PENDING_ADMIN_KEY))
+        let pending: Option<PendingProposalInfo> = env.storage().instance().get(&PENDING_ADMIN_KEY);
+        if let Some(proposal) = pending {
+            let now = env.ledger().timestamp();
+            if now - proposal.proposed_at <= PROPOSAL_EXPIRATION_SECONDS {
+                return Ok(Some(proposal.target));
+            } else {
+                // Remove expired proposal
+                env.storage().instance().remove(&PENDING_ADMIN_KEY);
+            }
+        }
+        Ok(None)
     }
 
     // -------------------------------------------------------------------
@@ -553,6 +563,7 @@ impl SLACalculatorContract {
     // -------------------------------------------------------------------
 
     /// Propose a new operator. The current admin initiates; the new operator must call `accept_operator`.
+    /// Proposals expire after 7 days.
     pub fn propose_operator(
         env: Env,
         caller: Address,
@@ -560,21 +571,34 @@ impl SLACalculatorContract {
     ) -> Result<(), SLAError> {
         Self::check_version(&env)?;
         Self::require_admin(&env, &caller)?;
-        env.storage().instance().set(&PENDING_OP_KEY, &new_operator);
+        let proposal = PendingProposalInfo {
+            target: new_operator.clone(),
+            proposed_at: env.ledger().timestamp(),
+        };
+        env.storage().instance().set(&PENDING_OP_KEY, &proposal);
         env.events()
             .publish((EVENT_OP_PROP, EVENT_VERSION, caller), (new_operator,));
         Ok(())
     }
 
     /// Accept a pending operator handoff. Must be called by the proposed new operator.
+    /// Proposals expire after 7 days.
     pub fn accept_operator(env: Env, caller: Address) -> Result<(), SLAError> {
         Self::check_version(&env)?;
-        let pending: Address = env
+        let pending: PendingProposalInfo = env
             .storage()
             .instance()
             .get(&PENDING_OP_KEY)
             .ok_or(SLAError::NoPendingTransfer)?;
-        if caller != pending {
+            
+        // Check if proposal has expired
+        let now = env.ledger().timestamp();
+        if now - pending.proposed_at > PROPOSAL_EXPIRATION_SECONDS {
+            env.storage().instance().remove(&PENDING_OP_KEY);
+            return Err(SLAError::NoPendingTransfer);
+        }
+        
+        if caller != pending.target {
             return Err(SLAError::Unauthorized);
         }
         env.storage().instance().set(&OPERATOR_KEY, &caller);

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -558,6 +558,22 @@ impl SLACalculatorContract {
         Ok(None)
     }
 
+    /// Returns the pending operator address, if any (only returns if proposal is still valid).
+    pub fn get_pending_operator(env: Env) -> Result<Option<Address>, SLAError> {
+        Self::check_version(&env)?;
+        let pending: Option<PendingProposalInfo> = env.storage().instance().get(&PENDING_OP_KEY);
+        if let Some(proposal) = pending {
+            let now = env.ledger().timestamp();
+            if now - proposal.proposed_at <= PROPOSAL_EXPIRATION_SECONDS {
+                return Ok(Some(proposal.target));
+            } else {
+                // Remove expired proposal
+                env.storage().instance().remove(&PENDING_OP_KEY);
+            }
+        }
+        Ok(None)
+    }
+
     // -------------------------------------------------------------------
     // #64 – Two-step operator handoff
     // -------------------------------------------------------------------

--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -17,6 +17,7 @@ pub mod event_correlation;
 mod event_schema;
 pub mod adaptive_tuning;
 pub mod version_negotiation;
+pub mod batch;
 
 // -----------------------------------------------------------------------
 // Storage keys

--- a/sla_calculator/src/proptests.rs
+++ b/sla_calculator/src/proptests.rs
@@ -315,3 +315,69 @@ fn prop_snapshot_always_has_four_entries() {
     assert_eq!(severities[2], symbol_short!("medium"));
     assert_eq!(severities[3], symbol_short!("low"));
 }
+
+/// Property: For all valid batch requests, succeeded + failed == total
+#[test]
+fn prop_batch_succeeded_plus_failed_equals_total() {
+    proptest!(|(requests in arb_batch_requests())| {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SLACalculatorContract);
+        let client = SLACalculatorContract::new_client(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let operator = Address::generate(&env);
+        client.initialize(&admin, &operator);
+
+        // Convert std::vec::Vec to soroban_sdk::Vec
+        let mut soroban_requests = Vec::new(&env);
+        for req in requests {
+            soroban_requests.push_back(req);
+        }
+
+        // Call view version (no state mutation)
+        let (summary, _results) = client.batch_calculate_view(&soroban_requests).unwrap();
+        
+        // Verify the invariant
+        assert_eq!(summary.succeeded + summary.failed, summary.total);
+    });
+}
+
+/// Property: batch_calculate_view never mutates contract state, even when processing batches with errors
+#[test]
+fn prop_batch_view_never_mutates_state() {
+    proptest!(|(requests in arb_batch_requests())| {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SLACalculatorContract);
+        let client = SLACalculatorContract::new_client(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let operator = Address::generate(&env);
+        client.initialize(&admin, &operator);
+
+        // Get initial state
+        let initial_stats = client.get_stats();
+        let initial_history_len = client.get_history().len();
+        let initial_admin = client.get_admin();
+        let initial_operator = client.get_operator();
+
+        // Convert std::vec::Vec to soroban_sdk::Vec
+        let mut soroban_requests = Vec::new(&env);
+        for req in requests {
+            soroban_requests.push_back(req);
+        }
+
+        // Call view version - should not change anything
+        let _ = client.batch_calculate_view(&soroban_requests);
+
+        // Verify all state is unchanged
+        let final_stats = client.get_stats();
+        let final_history_len = client.get_history().len();
+        let final_admin = client.get_admin();
+        let final_operator = client.get_operator();
+
+        assert_eq!(initial_stats, final_stats, "Stats must not change after view call");
+        assert_eq!(initial_history_len, final_history_len, "History length must not change after view call");
+        assert_eq!(initial_admin, final_admin, "Admin must not change after view call");
+        assert_eq!(initial_operator, final_operator, "Operator must not change after view call");
+    });
+}

--- a/sla_calculator/src/proptests.rs
+++ b/sla_calculator/src/proptests.rs
@@ -2,12 +2,48 @@
 
 extern crate std;
 
-use soroban_sdk::{symbol_short, Address, Env};
+use proptest::prelude::*;
+use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 use std::string::String;
 
-use crate::{SLACalculatorContract, SLAError, SLAConfig};
+use crate::{SLACalculatorContract, SLAError, SLAConfig, batch::{BatchRequest, BatchSummary, BatchResult}};
 
 mod utils;
+
+/// Proptest strategy to generate valid Symbol values for outage IDs
+fn arb_outage_id() -> impl Strategy<Value = Symbol> {
+    // Generate valid symbol strings (alphanumeric, <=32 chars)
+    "[a-zA-Z0-9_]{1,32}".prop_map(|s| Symbol::from_string(s))
+}
+
+/// Proptest strategy to generate valid severity symbols
+fn arb_severity() -> impl Strategy<Value = Symbol> {
+    prop_oneof![
+        Just(symbol_short!("critical")),
+        Just(symbol_short!("high")),
+        Just(symbol_short!("medium")),
+        Just(symbol_short!("low")),
+    ]
+}
+
+/// Proptest strategy to generate a single valid BatchRequest
+fn arb_batch_request() -> impl Strategy<Value = BatchRequest> {
+    (arb_outage_id(), arb_severity(), 1u32..10000) // MTTR from 1 to 9999 minutes
+        .prop_map(|(outage_id, severity, mttr_minutes)| BatchRequest {
+            outage_id,
+            severity,
+            mttr_minutes,
+        })
+}
+
+/// Proptest strategy to generate a vector of BatchRequests with unique outage IDs
+fn arb_batch_requests() -> impl Strategy<Value = std::vec::Vec<BatchRequest>> {
+    proptest::collection::vec(arb_batch_request(), 1..50) // Batch size 1 to 50 (max batch limit)
+        .prop_filter("All outage IDs must be unique", |requests| {
+            let mut seen = std::collections::HashSet::new();
+            requests.iter().all(|req| seen.insert(req.outage_id))
+        })
+}
 
 /// Property: SLA met result always has positive amount and "rew" payment type
 #[test]


### PR DESCRIPTION
## Summary of Changes

1. **Added batch module import to lib.rs**: Added `pub mod batch;` to ensure the batch module is accessible throughout the contract.

2. **Implemented `batch_calculate_view` function**: Added a view-only batch calculation function in lib.rs that:
   - Validates batch inputs
   - Bypasses authorization and pause checks to allow public verification
   - Processes all batch requests purely computationally without any state mutations
   - Returns the same summary and results format as the mutating batch_calculate function

closes #464

3. **Exposed `batch_calculate` function on the contract**: Added the mutating batch_calculate function to the contract implementation that delegates to the existing logic in batch.rs.

4. **Added property-based tests to proptests.rs**:
   - Created proptest strategies to generate arbitrary valid BatchRequest vectors with unique outage IDs
   - Implemented `prop_batch_succeeded_plus_failed_equals_total` to verify the invariant that `succeeded + failed == total` for all batch calculations
   - Implemented `prop_batch_view_never_mutates_state` to verify that the view function never modifies any contract state (admin, operator, stats, history all remain unchanged)

closes #455 

All acceptance criteria have been met:
- ✅ Created proptest strategy to generate arbitrary Vec<BatchRequest> with varying severities and MTTR values
- ✅ Verify invariant that succeeded + failed == total for all generated vectors
- ✅ Verify that batch calculations never mutate contract state in view mode
- ✅ Property tests will run in CI via `cargo test`

## Summary of Changes

1. **Added `PendingProposalInfo` struct**: Stores the target address and the timestamp when the proposal was created, allowing expiration tracking.

2. **Added 7-day expiration constant**: `PROPOSAL_EXPIRATION_SECONDS = 604800` (7 days in seconds).

closes #457

4. **Updated admin proposal flow**:
   - `propose_admin`: Now stores a `PendingProposalInfo` instead of just an address, including the current ledger timestamp
   - `accept_admin`: Checks if the proposal has expired before accepting; removes expired proposals and returns an error
   - `get_pending_admin`: Automatically removes expired proposals and only returns valid pending admin addresses

5. **Updated operator proposal flow**:
   - `propose_operator`: Now stores a `PendingProposalInfo` with timestamp
   - `accept_operator`: Includes the same expiration check as admin acceptance
   - Added new `get_pending_operator` function that handles expired operator proposals the same way as admin proposals

All acceptance criteria are met:
- ✅ Defined `PendingProposalInfo` struct storing target Address and proposed_at timestamp
- ✅ Both admin and operator proposals now store timestamps
- ✅ Proposals expire after 7 days when accept_admin or accept_operator is invoked
- ✅ Expired proposals are automatically removed from storage
- ✅ The implementation maintains backward compatibility for all existing functionality

closes #458