### PR TITLE
Add SLA result verification hash generator endpoint

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -865,6 +865,17 @@ impl SLACalculatorContract {
         Self::compute_config_version_hash(&env, &configs)
     }
 
+    /// Returns a deterministic hash of an SLAResult payload using the same
+    /// polynomial rolling hash algorithm as `get_config_version_hash`.
+    ///
+    /// Off-chain backend services can use this to verify whether a given
+    /// SLAResult matches an authentic contract outcome without re-executing
+    /// stateful calculation calls.
+    pub fn compute_result_hash(env: Env, result: SLAResult) -> Result<u64, SLAError> {
+        Self::check_version(&env)?;
+        Ok(Self::compute_result_hash_inner(&result))
+    }
+
     /// SC-W5-046 – Returns the full catalogue of typed failure codes.
     ///
     /// Backend bridge consumers call this once at startup to pre-load all
@@ -1621,6 +1632,38 @@ impl SLACalculatorContract {
         }
 
         Ok(hash.wrapping_mul(BASE).wrapping_add(0x9e3779b97f4a7c15u64) % MODULUS)
+    }
+
+    fn compute_result_hash_inner(result: &SLAResult) -> u64 {
+        const BASE: u64 = 91138233;
+        const MODULUS: u64 = (1u64 << 63) - 25;
+
+        let mut hash: u64 = 1;
+        let mut power: u64 = 1;
+
+        macro_rules! mix {
+            ($v:expr) => {
+                hash = hash
+                    .wrapping_mul(BASE)
+                    .wrapping_add($v as u64)
+                    .wrapping_mul(power)
+                    % MODULUS;
+                power = power.wrapping_mul(BASE) % MODULUS;
+            };
+        }
+
+        mix!(result.outage_id.to_val().get_payload());
+        mix!(result.status.to_val().get_payload());
+        mix!(result.mttr_minutes);
+        mix!(result.threshold_minutes);
+        mix!(result.amount as u64);
+        mix!((result.amount >> 64) as u64);
+        mix!(result.payment_type.to_val().get_payload());
+        mix!(result.rating.to_val().get_payload());
+        mix!(result.config_version_hash);
+        mix!(result.recorded_at);
+
+        hash.wrapping_mul(BASE).wrapping_add(0x9e3779b97f4a7c15u64) % MODULUS
     }
 
     /// Optimised config lookup with severity index pre-check for early rejection.

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -1661,6 +1661,80 @@ fn test_fixture_after_calculation_stats_are_updated() {
 }
 
 // ============================================================
+// #490 – SLA result verification hash
+// ============================================================
+
+#[test]
+fn test_compute_result_hash_is_deterministic() {
+    let (env, client, actors) = setup();
+
+    let result = client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("HASH001"),
+        &symbol_short!("critical"),
+        &5,
+    );
+
+    let h1 = client.compute_result_hash(&result);
+    let h2 = client.compute_result_hash(&result);
+    assert_eq!(h1, h2, "Hash must be deterministic for identical results");
+}
+
+#[test]
+fn test_compute_result_hash_differs_for_different_results() {
+    let (env, client, actors) = setup();
+
+    let result_a = client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("HASH002"),
+        &symbol_short!("critical"),
+        &5,
+    );
+
+    let result_b = client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("HASH003"),
+        &symbol_short!("critical"),
+        &25,
+    );
+
+    let ha = client.compute_result_hash(&result_a);
+    let hb = client.compute_result_hash(&result_b);
+    assert_ne!(
+        ha, hb,
+        "Different outage results must produce different hashes"
+    );
+}
+
+#[test]
+fn test_compute_result_hash_same_fields_identical_hash() {
+    let (env, client, actors) = setup();
+
+    // Two separate calculations with identical inputs
+    let r1 = client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("HASH_A"),
+        &symbol_short!("high"),
+        &20,
+    );
+    let r2 = client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("HASH_B"),
+        &symbol_short!("high"),
+        &20,
+    );
+
+    // Both should be "met" with identical computed result fields
+    // (except outage_id which differs)
+    let h1 = client.compute_result_hash(&r1);
+    let h2 = client.compute_result_hash(&r2);
+    assert_ne!(
+        h1, h2,
+        "Different outage_ids must produce different hashes"
+    );
+}
+
+// ============================================================
 // #95 – Negative tests for malformed symbol inputs
 // ============================================================
 


### PR DESCRIPTION
## Summary

Implemented a production-ready fix while maintaining the existing architecture and coding standards.

### Changes

- Added `compute_result_hash` public contract endpoint for off-chain result verification
- Uses polynomial rolling hash algorithm matching `get_config_version_hash`
- Added unit tests verifying hash determinism across identical result payloads
- Verified no unrelated changes were introduced

Closes #490