### PR TITLE
Add operator revocation administrative endpoint for emergency offboarding

### DIFF
--- a/sla_calculator/src/lib.rs
+++ b/sla_calculator/src/lib.rs
@@ -85,6 +85,7 @@ const EVENT_ADMIN_REN: Symbol = symbol_short!("adm_ren"); // #65
 const EVENT_OP_PROP: Symbol = symbol_short!("op_prop"); // #64
 const EVENT_OP_ACC: Symbol = symbol_short!("op_acc"); // #64
 const EVENT_OP_CAN: Symbol = symbol_short!("op_can"); // SC-024
+const EVENT_OP_REV: Symbol = symbol_short!("op_rev"); // #472
 const EVENT_VERSION: Symbol = symbol_short!("v1");
 
 // -----------------------------------------------------------------------
@@ -498,6 +499,28 @@ impl SLACalculatorContract {
         env.events().publish(
             (EVENT_OP_SET, EVENT_VERSION, caller),
             (new_operator.clone(),),
+        );
+
+        Ok(())
+    }
+
+    /// #472 – Revoke the operator role entirely (admin only).
+    ///
+    /// Removes the operator address and any pending operator proposal from
+    /// contract storage. After revocation, `calculate_sla` will fail with
+    /// `Unauthorized` until a new operator is configured via `set_operator`
+    /// or the two-step handoff (`propose_operator` / `accept_operator`).
+    /// Emits an `op_rev` event with the caller address context.
+    pub fn revoke_operator(env: Env, caller: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+
+        env.storage().instance().remove(&OPERATOR_KEY);
+        env.storage().instance().remove(&PENDING_OP_KEY);
+
+        env.events().publish(
+            (EVENT_OP_REV, EVENT_VERSION, caller),
+            (),
         );
 
         Ok(())

--- a/sla_calculator/src/tests.rs
+++ b/sla_calculator/src/tests.rs
@@ -412,6 +412,118 @@ fn test_old_operator_locked_out_after_rotation() {
 }
 
 // ============================================================
+// #472 – Operator revocation
+// ============================================================
+
+#[test]
+fn test_admin_can_revoke_operator() {
+    let (env, client, actors) = setup();
+
+    // Verify operator exists before revocation
+    assert_eq!(client.get_operator(), actors.operator);
+
+    // Revoke
+    client.revoke_operator(&actors.admin);
+
+    // Operator should be removed; no one can calculate SLA
+    let blocked = client.try_calculate_sla(
+        &actors.operator,
+        &symbol_short!("REV001"),
+        &symbol_short!("critical"),
+        &10,
+    );
+    assert!(
+        blocked.is_err(),
+        "calculate_sla must fail after operator revocation"
+    );
+}
+
+#[test]
+fn test_revoked_operator_cannot_calculate() {
+    let (env, client, actors) = setup();
+
+    client.revoke_operator(&actors.admin);
+
+    // The old operator cannot calculate
+    let result = client.try_calculate_sla(
+        &actors.operator,
+        &symbol_short!("REV002"),
+        &symbol_short!("critical"),
+        &10,
+    );
+    assert!(result.is_err(), "Revoked operator must be rejected");
+}
+
+#[test]
+fn test_revoked_operator_can_be_replaced() {
+    let (env, client, actors) = setup();
+    let new_operator = soroban_sdk::Address::generate(&env);
+
+    // Revoke current operator
+    client.revoke_operator(&actors.admin);
+
+    // Set a new operator
+    client.set_operator(&actors.admin, &new_operator);
+
+    // New operator can calculate
+    let result = client.calculate_sla(
+        &new_operator,
+        &symbol_short!("REV003"),
+        &symbol_short!("critical"),
+        &10,
+    );
+    assert_eq!(result.status, symbol_short!("met"));
+}
+
+#[test]
+fn test_revoke_operator_clears_pending_proposal() {
+    let (env, client, actors) = setup();
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    // Create a pending operator proposal
+    client.propose_operator(&actors.admin, &new_op);
+    assert_eq!(
+        client.get_pending_operator(),
+        Some(new_op.clone()),
+        "Pending operator must exist before revocation"
+    );
+
+    // Revoke clears both operator and pending proposal
+    client.revoke_operator(&actors.admin);
+
+    // Pending proposal is cleared
+    assert_eq!(
+        client.get_pending_operator(),
+        None,
+        "Pending operator must be cleared after revocation"
+    );
+
+    // A new operator proposal can be created for a different operator
+    let another_op = soroban_sdk::Address::generate(&env);
+    client.propose_operator(&actors.admin, &another_op);
+    assert_eq!(
+        client.get_pending_operator(),
+        Some(another_op),
+        "New operator proposal must work after revocation"
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_operator_cannot_revoke_self() {
+    let (env, client, actors) = setup();
+    // operator must not have admin authority to revoke
+    client.revoke_operator(&actors.operator);
+}
+
+#[test]
+#[should_panic]
+fn test_stranger_cannot_revoke_operator() {
+    let (env, client, actors) = setup();
+    client.revoke_operator(&actors.stranger);
+}
+
+// ============================================================
 // #27 – Pause / Emergency Stop
 // ============================================================
 


### PR DESCRIPTION
## Summary

Implemented a production-ready fix while maintaining the existing architecture and coding standards.

### Changes

- Implemented `revoke_operator` admin endpoint that removes operator and pending operator proposal from storage
- Emits `op_rev` event with caller address context
- Returns `Unauthorized` error on subsequent `calculate_sla` calls until a new operator is configured
- Added unit tests for revocation, replacement, and pending proposal clearing workflows

Closes #472
Closes #473 
Closes #474 
Closes #480 